### PR TITLE
[#13] feat/공통API 내체험

### DIFF
--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -94,3 +94,19 @@ export const DELETE = async (request: NextRequest) => {
     return errorResponse(error);
   }
 };
+
+export const PATCH = async (request: NextRequest) => {
+  const url = new URL(request.url);
+  const endPoint = url.pathname.replace(/^\/api/, '');
+  
+  try {
+    const apiResponse = await axiosServerHelper.patch(endPoint, await request.json());
+    if (isEmpty(apiResponse.data))
+      return new NextResponse(null, {
+        status: apiResponse.status,
+      });
+    return NextResponse.json(apiResponse.data, { status: apiResponse.status });
+  } catch (error) {
+    return errorResponse(error);
+  }
+};

--- a/src/lib/apis/myActivities.ts
+++ b/src/lib/apis/myActivities.ts
@@ -4,7 +4,7 @@ import { MyActivitiesResponse, myActivitiesResponseSchema, ReservationDashboardR
 
 /*
  * 내 체험 리스트 조회 API
- * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-my-activities
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/FindByUserId
  */
 export const getMyActivities = async (
   cursorId?: number,
@@ -19,7 +19,7 @@ export const getMyActivities = async (
 
 /*
  * 내 체험 월별 예약 현황 조회 API
- * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-reservation-dashboard
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/FindReservationsByMonth
  */
 export const getReservationDashboard = async (
     activityId: number,
@@ -35,7 +35,7 @@ export const getReservationDashboard = async (
 
 /*
  * 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케쥴 조회 API
- * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-reserved-schedule
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/FindReservedSchedule
  */
 export const getReservedSchedule = async (
     activityId: number,
@@ -50,7 +50,7 @@ export const getReservedSchedule = async (
 
 /*
  * 내 체험 예약 시간대별 예약 내역 조회 API
- * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-reservations
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/FindReservations
  */
 export const getReservations = async (
     activityId: number,
@@ -71,7 +71,7 @@ export const getReservations = async (
 
 /*
  * 내 체험 예약 상태(승인, 거절) 업데이트 API
- * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Patch-reservationStatus
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/UpdateReservations
  */
 export const updateReservationStatus = async (
     activityId: number,
@@ -99,7 +99,7 @@ export const deleteActivity = async (
 
 /*
  * 내 체험 수정 API
- * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Patch-myActivities
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Update
  */
 export const updateActivity = async (
     activityId: number,

--- a/src/lib/apis/myActivities.ts
+++ b/src/lib/apis/myActivities.ts
@@ -1,0 +1,110 @@
+import axiosClientHelper from '../network/axiosClientHelper';
+import { safeResponse } from '..//network/safeResponse';
+import { MyActivitiesResponse, myActivitiesResponseSchema, ReservationDashboardResponse, reservationDashboardResponseSchema, ReservedScheduleResponse, reservedScheduleResponseSchema, ReservationResponse, reservationResponseSchema, UpdateReservationStatusResponse, updateReservationStatusResponseSchema, DeleteActivityResponse, deleteActivityResponseSchema, UpdatedActivityResponse, updatedActivityResponseSchema, UpdateActivityRequest } from '../types/myActivities';
+
+/*
+ * 내 체험 리스트 조회 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-my-activities
+ */
+export const getMyActivities = async (
+  cursorId?: number,
+  size: number = 20,
+): Promise<MyActivitiesResponse> => {
+  const response = await axiosClientHelper.get<MyActivitiesResponse>('/my-activities', {
+    params: { cursorId, size },
+  });
+  return safeResponse(response.data, myActivitiesResponseSchema);
+};
+
+
+/*
+ * 내 체험 월별 예약 현황 조회 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-reservation-dashboard
+ */
+export const getReservationDashboard = async (
+    activityId: number,
+    year: string,
+    month: string
+  ): Promise<ReservationDashboardResponse> => {
+    const response = await axiosClientHelper.get<ReservationDashboardResponse[]>(`/my-activities/${activityId}/reservation-dashboard`, {
+      params: { year, month },
+    });
+    return safeResponse(response.data, reservationDashboardResponseSchema);
+  };
+
+
+/*
+ * 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케쥴 조회 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-reserved-schedule
+ */
+export const getReservedSchedule = async (
+    activityId: number,
+    date: string
+  ): Promise<ReservedScheduleResponse> => {
+    const response = await axiosClientHelper.get<ReservedScheduleResponse[]>(`/my-activities/${activityId}/reserved-schedule`, {
+      params: { date },
+    });
+    return safeResponse(response.data, reservedScheduleResponseSchema);
+  };
+
+
+/*
+ * 내 체험 예약 시간대별 예약 내역 조회 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Get-reservations
+ */
+export const getReservations = async (
+    activityId: number,
+    scheduleId: number,
+    status: 'declined' | 'pending' | 'confirmed',
+    cursorId?: number,
+    size: number = 10,
+  ): Promise<ReservationResponse> => {
+    const params = { scheduleId, status, cursorId, size };
+
+    const response = await axiosClientHelper.get<ReservationResponse>(
+        `/my-activities/${activityId}/reservations`,
+        { params }
+    );
+    return safeResponse(response.data, reservationResponseSchema);
+  };
+
+
+/*
+ * 내 체험 예약 상태(승인, 거절) 업데이트 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Patch-reservationStatus
+ */
+export const updateReservationStatus = async (
+    activityId: number,
+    reservationId: number,
+    status: 'declined' | 'confirmed'
+  ): Promise<UpdateReservationStatusResponse> => {
+    const response = await axiosClientHelper.patch<UpdateReservationStatusResponse>(`/my-activities/${activityId}/reservations/${reservationId}`, {
+      status,
+    });
+    return safeResponse(response.data, updateReservationStatusResponseSchema);
+  };
+
+
+/*
+ * 내 체험 삭제 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Delete
+ */
+export const deleteActivity = async (
+    activityId: number
+  ): Promise<DeleteActivityResponse> => {
+    const response = await axiosClientHelper.delete<DeleteActivityResponse>(`/my-activities/${activityId}`);
+    return safeResponse(response.data, deleteActivityResponseSchema);
+  };
+
+
+/*
+ * 내 체험 수정 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyActivities/Patch-myActivities
+ */
+export const updateActivity = async (
+    activityId: number,
+    data: UpdateActivityRequest
+  ): Promise<UpdatedActivityResponse> => {
+    const response = await axiosClientHelper.patch<UpdatedActivityResponse>(`/my-activities/${activityId}`, data);
+    return safeResponse(response.data, updatedActivityResponseSchema);
+  };

--- a/src/lib/hooks/useMyActivities.ts
+++ b/src/lib/hooks/useMyActivities.ts
@@ -1,0 +1,72 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { getMyActivities, getReservationDashboard, getReservedSchedule, getReservations, updateReservationStatus, deleteActivity, updateActivity } from '../apis/myActivities';
+
+// 내 체험 리스트 조회 훅
+export const useMyActivities = (cursorId?: number, size: number = 20) => {
+    return useQuery({
+      queryKey: ['myActivities', cursorId, size],
+      queryFn: () => getMyActivities(cursorId, size),
+      staleTime: 30000,
+    });
+  };
+
+
+// 내 체험 월별 예약 현황 조회 훅
+export const useReservationDashboard = (activityId: number, year: string, month: string) => {
+    return useQuery({
+      queryKey: ['reservationDashboard', activityId, year, month],
+      queryFn: () => getReservationDashboard(activityId, year, month),
+      staleTime: 30000,
+    });
+  };
+
+
+// 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케쥴 조회 훅
+export const useReservedSchedule = (activityId: number, date: string) => {
+    return useQuery({
+      queryKey: ['reservedSchedule', activityId, date],
+      queryFn: () => getReservedSchedule(activityId, date),
+      staleTime: 30000,
+    });
+  };
+
+
+// 내 체험 예약 시간대별 예약 내역 조회 훅
+export const useReservations = (
+    activityId: number,
+    scheduledId: number,
+    status: 'declined' | 'pending' | 'confirmed',
+    cursorId?: number,
+    size: number = 10,
+  ) => {
+    return useQuery({
+      queryKey: ['reservations', activityId, scheduledId, status, cursorId, size],
+      queryFn: () => getReservations(activityId, scheduledId, status, cursorId, size),
+      staleTime: 30000,
+    });
+};
+
+
+// 내 체험 예약 상태(승인, 거절) 업데이트 훅
+export const useUpdateReservationStatus = () => {
+    return useMutation({
+      mutationFn: (data: { activityId: number; reservationId: number; status: 'declined' | 'confirmed' }) =>
+        updateReservationStatus(data.activityId, data.reservationId, data.status),
+    });
+  };
+
+
+// 내 체험 삭제 훅
+export const useDeleteActivity = () => {
+    return useMutation({
+      mutationFn: (activityId: number) => deleteActivity(activityId),
+    });
+  };
+
+
+// 내 체험 수정 훅
+export const useUpdateActivity = () => {
+    return useMutation({
+      mutationFn: (params: { activityId: number, data: any }) => updateActivity(params.activityId, params.data),
+    });
+  };

--- a/src/lib/hooks/useMyActivities.ts
+++ b/src/lib/hooks/useMyActivities.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { getMyActivities, getReservationDashboard, getReservedSchedule, getReservations, updateReservationStatus, deleteActivity, updateActivity } from '../apis/myActivities';
+import { UpdateActivityRequest } from '../types/myActivities';
 
 // 내 체험 리스트 조회 훅
 export const useMyActivities = (cursorId?: number, size: number = 20) => {
@@ -67,6 +68,6 @@ export const useDeleteActivity = () => {
 // 내 체험 수정 훅
 export const useUpdateActivity = () => {
     return useMutation({
-      mutationFn: (params: { activityId: number, data: any }) => updateActivity(params.activityId, params.data),
+      mutationFn: (params: { activityId: number, data: UpdateActivityRequest }) => updateActivity(params.activityId, params.data),
     });
   };

--- a/src/lib/types/myActivities.ts
+++ b/src/lib/types/myActivities.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+
+// 내 체험 리스트 조회 API 타입
+export const activityBasicSchema = z.object({
+  id: z.number(),
+  userId: z.number(),
+  title: z.string(),
+  description: z.string(),
+  category: z.string(),
+  price: z.number(),
+  address: z.string(),
+  bannerImageUrl: z.string(),
+  rating: z.number(),
+  reviewCount: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const myActivitiesResponseSchema = z.object({
+  cursorId: z.number().nullable(),
+  totalCount: z.number(),
+  activities: z.array(activityBasicSchema),
+});
+
+export type ActivityBasic = z.infer<typeof activityBasicSchema>;
+export type MyActivitiesResponse = z.infer<typeof myActivitiesResponseSchema>;
+
+
+// 내 체험 월별 예약 현황 조회 API 타입
+export const reservationDashboardResponseSchema = z.array(
+    z.object({
+      date: z.string(),
+      reservations: z.object({
+        pending: z.number(),
+        confirmed: z.number(),
+        completed: z.number(),
+      }),
+    })
+  );
+  
+export type ReservationDashboardResponse = z.infer<typeof reservationDashboardResponseSchema>;
+
+
+// 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케쥴 조회 API 타입
+export const reservedScheduleResponseSchema = z.array(
+    z.object({
+      scheduleId: z.number(),
+      startTime: z.string(),
+      endTime: z.string(),
+      count: z.object({
+        declined: z.number(),
+        confirmed: z.number(),
+        pending: z.number(),
+      }),
+    })
+  );
+  
+export type ReservedScheduleResponse = z.infer<typeof reservedScheduleResponseSchema>;
+
+
+// 내 체험 예약 시간대별 예약 내역 조회 API 타입
+export const reservationResponseSchema = z.object({
+    cursorId: z.number().nullable(),
+    totalCount: z.number(),
+    reservations: z.array(
+      z.object({
+        id: z.number(),
+        nickname: z.string(),
+        userId: z.number(),
+        teamId: z.string(),
+        activityId: z.number(),
+        scheduleId: z.number(),
+        status: z.string(),
+        reviewSubmitted: z.boolean(),
+        totalPrice: z.number(),
+        headCount: z.number(),
+        date: z.string(),
+        startTime: z.string(),
+        endTime: z.string(),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+      })
+    ),
+  });
+  
+export type ReservationResponse = z.infer<typeof reservationResponseSchema>;
+  
+
+// 내 체험 예약 상태(승인, 거절) 업데이트 API 타입
+export const updateReservationStatusResponseSchema = z.object({
+    id: z.number(),
+    teamId: z.string(),
+    userId: z.number(),
+    activityId: z.number(),
+    scheduleId: z.number(),
+    status: z.enum(['pending', 'confirmed', 'declined', 'canceled', 'completed']),
+    reviewSubmitted: z.boolean(),
+    totalPrice: z.number(),
+    headCount: z.number(),
+    date: z.string(),
+    startTime: z.string(),
+    endTime: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  });
+  
+export type UpdateReservationStatusResponse = z.infer<typeof updateReservationStatusResponseSchema>;
+
+
+// 내 체험 삭제 API 타입
+export const deleteActivityResponseSchema = z.object({});
+
+export type DeleteActivityResponse = z.infer<typeof deleteActivityResponseSchema>;
+
+
+// 내 체험 수정 API 타입
+export const updateActivityRequestSchema = z.object({
+  title: z.string(),
+  category: z.string(),
+  description: z.string(),
+  price: z.number(),
+  address: z.string(),
+  bannerImageUrl: z.string(),
+  subImageIdsToRemove: z.array(z.number()),
+  subImageUrlsToAdd: z.array(z.string()),
+  scheduleIdsToRemove: z.array(z.number()),
+  schedulesToAdd: z.array(
+    z.object({
+      date: z.string(),
+      startTime: z.string(),
+      endTime: z.string(),
+    })
+  ),
+});
+
+export type UpdateActivityRequest = z.infer<typeof updateActivityRequestSchema>;
+
+export const updatedActivityResponseSchema = z.object({
+    id: z.number(),
+    userId: z.number(),
+    title: z.string(),
+    description: z.string(),
+    category: z.string(),
+    price: z.number(),
+    address: z.string(),
+    bannerImageUrl: z.string(),
+    rating: z.number(),
+    reviewCount: z.number(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    subImages: z.array(
+      z.object({
+        imageUrl: z.string(),
+        id: z.number(),
+      })
+    ),
+    schedules: z.array(
+      z.object({
+        date: z.string(),
+        times: z.array(
+          z.object({
+            startTime: z.string(),
+            endTime: z.string(),
+            id: z.number(),
+          })
+        ),
+      })
+    ),
+  });
+  
+  export type UpdatedActivityResponse = z.infer<typeof updatedActivityResponseSchema>;


### PR DESCRIPTION
## :hash: Issue

- #13  

## :memo: Description

- app/api/[...endpoint]/route.ts 에서 PATCH 메소드를 추가하였습니다.

- 공통 API에서 내 체험(myActivities) 카테고리 안의 7개의 엔드포인트를 구현하였습니다.
- lib/apis/myActivities.ts : 여러 내 체험 관련 API 요청 함수들을 정의, 각 함수는 해당하는 API 엔드포인트에 요청을 보내고, safeResponse를 사용해 응답을 안전하게 처리합니다.
- lib/hooks/useMyActivites.ts: React Query를 사용하여 API를 호출하는 훅을 정의, 데이터를 요청하고, 반환된 데이터를 관리하는 용도로 사용됩니다.
- lib/types/myActivites.ts: 각 API 응답에 대한 타입 정의, zod 라이브러리를 사용하여 응답을 검증하고 타입을 정의합니다.


## :white_check_mark: Checklist

### PR Checklist
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes
- [x] lib/types/myActivites.ts 에서 내 체험 수정 API 타입에는 UpdateActivityRequest 도 정의되어 있습니다.
해당 API를 사용하는 부분에서 이 타입을 사용하시면 됩니다.

