### PR TITLE
[#27] feat/공통API 로그인, 토큰재발급

### DIFF
--- a/src/lib/apis/auth.ts
+++ b/src/lib/apis/auth.ts
@@ -1,0 +1,27 @@
+import axiosClientHelper from '../network/axiosClientHelper';
+import { safeResponse } from '../network/safeResponse';
+import {
+  LoginParams,
+  LoginResponse,
+  loginResponseSchema,
+  RefreshTokenResponse,
+  refreshTokenResponseSchema,
+} from '../types/auth';
+
+/*
+ * 로그인 요청 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/Auth/Login
+ */
+export const login = async (data: LoginParams) => {
+  const response = await axiosClientHelper.post<LoginResponse>('/auth/login', data);
+  return safeResponse(response.data, loginResponseSchema);
+};
+
+/*
+ * 토큰 재발급 요청 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/Auth/Refresh
+ */
+export const refreshToken = async () => {
+  const response = await axiosClientHelper.post<RefreshTokenResponse>('/auth/tokens');
+  return safeResponse(response.data, refreshTokenResponseSchema);
+};

--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import { login, refreshToken } from '../apis/auth';
+import { LoginParams, LoginResponse, RefreshTokenResponse } from '../types/auth';
+
+// // 1. 로그인 훅
+export const useLogin = () => {
+  return useMutation<LoginResponse, unknown, LoginParams>({
+    mutationFn: login,
+  });
+};
+
+// // 2. 토큰 재발급 훅
+export const useRefreshToken = () => {
+  return useMutation<RefreshTokenResponse, unknown, void>({
+    mutationFn: refreshToken,
+  });
+};

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+// 로그인 요청 API 타입
+export const loginSchema = z.object({
+  email: z.string().email(), // 이메일
+  password: z.string(), // 비밀번호
+});
+export type LoginParams = z.infer<typeof loginSchema>;
+
+// 로그인 응답 API 타입
+export const loginResponseSchema = z.object({
+  user: z.object({
+    id: z.number(),
+    email: z.string(),
+    nickname: z.string(),
+    profileImageUrl: z.string().nullable(),
+    createdAt: z.string(), // ISO date string
+    updatedAt: z.string(),
+  }),
+  refreshToken: z.string(),
+  accessToken: z.string(),
+});
+export type LoginResponse = z.infer<typeof loginResponseSchema>;
+
+// 토큰 재발급 응답 API 타입
+export const refreshTokenResponseSchema = z.object({
+  refreshToken: z.string(),
+  accessToken: z.string(),
+});
+export type RefreshTokenResponse = z.infer<typeof refreshTokenResponseSchema>;


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -close #을 입력하면 이슈 번호가 나타납니다. -->
- close #27  

## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
Auth 도메인에 대한 다음 파일들 생성 및 코드 추가
- lib/types/auth.ts
- lib/apis/auth.ts
- lib/hooks/useAuth.ts

구현한 API
- 로그인 (POST /{teamId}/auth/login)
- 토큰 재발급 (POST /{teamId}/auth/tokens)


정상 동작 확인
- 랜딩 페이지(page.tsx)에서 임시로 테스트 코드 작성 후 실제 API 호출 확인 완료.
- 로그인, 토큰 재발급 모두 성공 확인 (콘솔 로그 및 alert 활용).
![로그인api테스트](https://github.com/user-attachments/assets/caeb6650-31f5-4d94-888d-53d1c8090a31)
![리프레시토큰api 테스트](https://github.com/user-attachments/assets/fcbc9846-dc2a-4950-a996-370632b97604)

임시 코드 관련
- 현재 lib/network/axiosServerHelper.ts에서 accessToken이 쿠키에 존재해야 요청 가능한 구조라 테스트를 위해 임시로 axios 직접 호출 방식으로 API 테스트 진행.
- 프로덕션 환경에서는 현재 axiosServerHelper 구조가 유지되어야 하기 때문에, 테스트 용도 코드만 따로 작성 후 본 PR에 포함하지 않음.


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
