### PR TITLE
[#21] feat/공통API 내예약

### DIFF
--- a/src/lib/apis/myReservation.ts
+++ b/src/lib/apis/myReservation.ts
@@ -1,0 +1,50 @@
+import axiosClientHelper from '../network/axiosClientHelper';
+import { safeResponse } from '../network/safeResponse';
+import { GetMyReservationsResponse, getMyReservationsResponseSchema, ReservationUpdateResponse, ReviewResponse, reservationUpdateResponseSchema, reviewResponseSchema } from '../types/myReservation';
+
+/*
+ * 내 예약 리스트 조회 API 
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyReservations/Find
+ */
+export const getMyReservations = async (
+  cursorId?: number,
+  size: number = 10,
+  status?: string
+): Promise<GetMyReservationsResponse> => {
+  const response = await axiosClientHelper.get<GetMyReservationsResponse>('/my-reservations', {
+    params: { cursorId, size, status },
+  });
+  return safeResponse(response.data, getMyReservationsResponseSchema);
+};
+
+
+/*
+ * 내 예약 수정 (취소) API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyReservations/Update
+ */
+export const cancelMyReservation = async (
+  reservationId: number,
+  status: 'canceled'
+): Promise<ReservationUpdateResponse> => {
+  const response = await axiosClientHelper.patch<ReservationUpdateResponse>(`/my-reservations/${reservationId}`, {
+    status,
+  });
+  return safeResponse(response.data, reservationUpdateResponseSchema);
+};
+
+
+/*
+ * 내 예약 리뷰 작성 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/MyReservations/CreateReview
+ */
+export const writeReviewForReservation = async (
+  reservationId: number,
+  rating: number,
+  content: string
+): Promise<ReviewResponse> => {
+  const response = await axiosClientHelper.post<ReviewResponse>(`/my-reservations/${reservationId}/reviews`, {
+    rating,
+    content,
+  });
+  return safeResponse(response.data, reviewResponseSchema);
+};

--- a/src/lib/hooks/useMyReservation.ts
+++ b/src/lib/hooks/useMyReservation.ts
@@ -1,0 +1,28 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { getMyReservations, cancelMyReservation, writeReviewForReservation } from '../apis/myReservation';
+
+// 내 예약 리스트 조회 훅
+export const useMyReservations = (cursorId?: number, size: number = 10, status?: string) => {
+  return useQuery({
+    queryKey: ['myReservations', cursorId, size, status],
+    queryFn: () => getMyReservations(cursorId, size, status),
+    staleTime: 30000,
+  });
+};
+
+
+// 내 예약 취소 훅
+export const useCancelMyReservation = () => {
+  return useMutation({
+    mutationFn: (reservationId: number) => cancelMyReservation(reservationId, 'canceled'),
+  });
+};
+
+
+// 내 예약 리뷰 작성 훅
+export const useWriteReviewForReservation = () => {
+  return useMutation({
+    mutationFn: (data: { reservationId: number; rating: number; content: string }) =>
+      writeReviewForReservation(data.reservationId, data.rating, data.content),
+  });
+};

--- a/src/lib/types/myReservation.ts
+++ b/src/lib/types/myReservation.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+// 내 예약 리스트 조회 API 타입
+export const reservationWithActivitySchema = z.object({
+  id: z.number(),
+  teamId: z.string(),
+  userId: z.number(),
+  activity: z.object({
+    bannerImageUrl: z.string(),
+    title: z.string(),
+    id: z.number(),
+  }),
+  scheduleId: z.number(),
+  status: z.enum(['pending', 'confirmed', 'declined', 'canceled', 'completed']),
+  reviewSubmitted: z.boolean(),
+  totalPrice: z.number(),
+  headCount: z.number(),
+  date: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const getMyReservationsResponseSchema = z.object({
+  cursorId: z.number().nullable(),
+  reservations: z.array(reservationWithActivitySchema),
+  totalCount: z.number(),
+});
+
+export type ReservationWithActivity = z.infer<typeof reservationWithActivitySchema>;
+export type GetMyReservationsResponse = z.infer<typeof getMyReservationsResponseSchema>;
+
+
+// 내 예약 수정 (취소) API 타입
+export const cancelReservationRequestSchema = z.object({
+    status: z.enum(['canceled']),
+  });
+  
+export type CancelReservationRequest = z.infer<typeof cancelReservationRequestSchema>;
+
+export const reservationUpdateResponseSchema = z.object({
+    id: z.number(),
+    teamId: z.string(),
+    userId: z.number(),
+    activityId: z.number(),
+    scheduleId: z.number(),
+    status: z.enum(['pending', 'confirmed', 'declined', 'canceled', 'completed']),
+    reviewSubmitted: z.boolean(),
+    totalPrice: z.number(),
+    headCount: z.number(),
+    date: z.string(),
+    startTime: z.string(),
+    endTime: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  });
+  
+  export type ReservationUpdateResponse = z.infer<typeof reservationUpdateResponseSchema>;
+  
+
+// 내 예약 리뷰 작성 API 타입
+export const createReviewRequestSchema = z.object({
+  rating: z.number().min(1, '별점은 1 이상이어야 합니다.').max(5, '별점은 5 이하이어야 합니다.'), 
+  content: z
+    .string()
+    .min(1, { message: '후기 내용을 입력해주세요.' })
+    .regex(/^[a-zA-Z0-9가-힣\s\.,!?]+$/, { message: '후기 내용은 문자, 숫자, 공백, 일부 특수문자만 포함할 수 있습니다.' })
+});
+  
+export type CreateReviewRequest = z.infer<typeof createReviewRequestSchema>;
+
+export const reviewResponseSchema = z.object({
+    deletedAt: z.string().nullable(),
+    updatedAt: z.string(),
+    createdAt: z.string(),
+    content: z.string(),
+    rating: z.number(),
+    userId: z.number(),
+    activityId: z.number(),
+    teamId: z.string(),
+    id: z.number(),
+  });
+  
+  export type ReviewResponse = z.infer<typeof reviewResponseSchema>;
+  


### PR DESCRIPTION
## :hash: Issue

- #21  

## :memo: Description

- 공통 API에서 내 예약(myReservations) 카테고리 안의 3개의 엔드포인트를 구현하였습니다.
- lib/apis/myReservation.ts : 내 예약 관련 API 요청 함수들을 정의, 각 함수는 해당하는 API 엔드포인트에 요청을 보내고, safeResponse를 사용해 응답을 안전하게 처리합니다.
- lib/hooks/useMyReservation.ts: React Query를 사용하여 API를 호출하는 훅을 정의, 데이터를 요청하고, 반환된 데이터를 관리하는 용도로 사용됩니다.
- lib/types/myReservation.ts: 각 API 응답에 대한 타입 정의, zod 라이브러리를 사용하여 응답을 검증하고 타입을 정의합니다.

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [ ] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
