### PR TITLE
[#28] feat/간편로그인 API 추상화

### DIFF
--- a/src/lib/apis/oauth.ts
+++ b/src/lib/apis/oauth.ts
@@ -1,0 +1,38 @@
+import axiosClientHelper from '../network/axiosClientHelper';
+import { safeResponse } from '../network/safeResponse';
+import {
+  OauthAppParams,
+  OauthAppResponse,
+  oauthAppResponseSchema,
+  OauthParams,
+  OauthResponse,
+  oauthResponseSchema,
+  // Provider,
+} from '../types/oauth';
+
+/**
+ * 간편 로그인 App 등록/수정 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/Oauth/UpsertOauthApp
+ */
+export const postOauthApps = async (params: OauthAppParams) => {
+  const response = await axiosClientHelper.post<OauthAppResponse>('/oauth/apps', params);
+  return safeResponse(response.data, oauthAppResponseSchema);
+};
+
+/*
+ * 간편 회원가입 API
+ * https://sp-globalnomad-api.vercel.app/docs/#/Oauth/SignUpOauth
+ */
+export const postOauthSignup = async (provider: 'google' | 'kakao', data: OauthParams) => {
+  const response = await axiosClientHelper.post<OauthResponse>(`/oauth/sign-up/${provider}`, data);
+  return safeResponse(response.data, oauthResponseSchema);
+};
+
+/*
+ * 간편 로그인
+ * https://sp-globalnomad-api.vercel.app/docs/#/Oauth/SignInOauth
+ */
+export const postOauthLogin = async (provider: 'google' | 'kakao', data: OauthParams) => {
+  const response = await axiosClientHelper.post<OauthResponse>(`/oauth/sign-in/${provider}`, data);
+  return safeResponse(response.data, oauthResponseSchema);
+};

--- a/src/lib/hooks/useOauth.ts
+++ b/src/lib/hooks/useOauth.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { OauthAppParams, OauthAppResponse, OauthParams, OauthResponse } from '../types/oauth';
+import { postOauthApps, postOauthLogin, postOauthSignup } from '../apis/oauth';
+
+// 간편 로그인 App 등록/수정 훅
+export const useOauthApps = (params: OauthAppParams) => {
+  return useMutation<OauthAppResponse, Error, OauthAppParams>({
+    mutationFn: () => postOauthApps(params),
+  });
+};
+
+// 간편 회원가입 훅
+export const useOauthSignup = (provider: 'google' | 'kakao') => {
+  return useMutation<OauthResponse, Error, OauthParams>({
+    mutationFn: async (data: OauthParams) => {
+      if (data.nickname) {
+        return postOauthSignup(provider, data);
+      }
+      throw new Error('Nickname is required');
+    },
+  });
+};
+
+// 간편 로그인 훅
+export const useOauthLogin = (provider: 'google' | 'kakao') => {
+  return useMutation<OauthResponse, Error, OauthParams>({
+    mutationFn: async (data: OauthParams) => {
+      return postOauthLogin(provider, data); // 그냥 보내기
+    },
+  });
+};

--- a/src/lib/types/oauth.ts
+++ b/src/lib/types/oauth.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+// 간편 로그인 App 등록 / 수정
+export const oauthAppParamsSchema = z.object({
+  appKey: z.string(),
+  provider: z.enum(['kakao', 'google']),
+});
+
+export type OauthAppParams = z.infer<typeof oauthAppParamsSchema>;
+
+export const oauthAppResponseSchema = z.object({
+  id: z.number(),
+  provider: z.enum(['kakao', 'google']),
+  teamId: z.string(),
+  appKey: z.string(),
+  createdAt: z.union([z.string(), z.date()]),
+  updatedAt: z.union([z.string(), z.date()]),
+});
+
+export type OauthAppResponse = z.infer<typeof oauthAppResponseSchema>;
+
+// 간편 회원가입 및 로그인
+export const oauthParamsSchema = z.object({
+  nickname: z.string().optional(),
+  redirectUri: z.string().url(),
+  token: z.string(),
+});
+
+export type OauthParams = z.infer<typeof oauthParamsSchema>;
+
+export const oauthLoginParamsSchema = z.object({
+  nickname: z.string().optional(),
+  redirectUri: z.string().url(),
+  token: z.string(),
+});
+
+export type OauthLoginParams = z.infer<typeof oauthLoginParamsSchema>;
+
+export const oauthUserSchema = z.object({
+  id: z.number(),
+  email: z.string(),
+  nickname: z.string(),
+  profileImageUrl: z.string(),
+  createdAt: z.union([z.string(), z.date()]),
+  updatedAt: z.union([z.string(), z.date()]),
+});
+
+export const oauthResponseSchema = z.object({
+  user: oauthUserSchema,
+  refreshToken: z.string(),
+  accessToken: z.string(),
+});
+
+export type OauthResponse = z.infer<typeof oauthResponseSchema>;


### PR DESCRIPTION
## :hash: Issue
 - close #28 
<!-- 이슈 번호를 작성해 주세요. -close #을 입력하면 이슈 번호가 나타납니다. -->

## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
 - 간편 api 추상화 작업 완료
 - 간편로그인 기능을 구현해야 api 결과를 확실히 볼 수 있을 것 같았으나 오류가 발생해서 API 관련 내용만 첨부

## 테스트에 필요한 파일

 - 'token'으로 요구되는 값은 '인가코드'입니다.
 
<img width="325" alt="스크린샷 2025-03-17 오후 2 54 08" src="https://github.com/user-attachments/assets/83c2c021-53b3-40eb-ab4d-45bfe720eb7d" />

- 인가코드는 redirectUri 설정을 하면 url 쿼리로 값이 반환됩니다. redirectUri는 app 내부에 존재하는 파일이어야합니다. 저는 'http://localhost:3000/oauth/kakao' 경로로 사용했습니다.
- ⚠️ 위에 처럼 설정 시 해당 파일은 app/oauth/kakao/page.tsx 파일 경로를 따릅니다. redirectUri 페이지는 로그인 성공 후 이동 될 페이지로 작성하시면 됩니다. 저는 스웨거에 샘플로 있는 페이지에 테스트했습니다.

``` js
// 버튼 만들 페이지.tsx
'use client';

import { KAKAO_LOGIN_URL } from '@/components/constants';
import Link from 'next/link';

export default function Page() {
  return (
    <div>
        {/* {KAKAO_LOGIN_URL} 은 상수 컴포넌트 파일을 만들어서 관리합니다. */}
      <Link href={KAKAO_LOGIN_URL}>
        <button>카카오로 로그인</button>
      </Link>
    </div>
  );
}
```

```js
// constant.tsx
export const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI}&scope=profile_nickname,account_email`;

// .env
{/* REST_API_KEY는 카카오 디벨로퍼스 페이지에서 앱 생성 후 '앱키'에서 확인 가능합니다. */}
NEXT_PUBLIC_KAKAO_REST_API_KEY=1d452343e4688a5a35211aae3eea1ea3
NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URI=http://localhost:3000/oauth/kakao
```

``` js
// app/oauth/kakao/page.tsx
'use client';

const KakaoLogin = () => {
  const params = useSearchParams();
  const code = params.get('code');
  return (
    <div>
      <h1>카카오 로그인 완료</h1>
      {code}
    </div>
  );
};

export default KakaoLogin;

```
위에 파일 작업 후에 로그인하면
<img width="557" alt="스크린샷 2025-03-17 오후 3 23 32" src="https://github.com/user-attachments/assets/0c9e1d99-29c6-46c0-a188-1eb9656eb6fa" />
?code=@@@@@ 부분의 쿼리를 '인가코드'로 불러옵니다.

저는 계속 여기서 오류가 발생해서 reponse값을 제대로 확인하지는 못했습니다.
<img width="770" alt="스크린샷 2025-03-17 오후 3 25 38" src="https://github.com/user-attachments/assets/167efc60-fed8-487e-9a63-91f646c46469" />
<img width="513" alt="스크린샷 2025-03-17 오후 3 25 54" src="https://github.com/user-attachments/assets/76adc5b1-13d5-4d14-85ab-9410c5cb459f" />

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] 이후 작업은 인풋 공통컴포넌트 작성하겠습니다.
