### PR TITLE
[#60] refactor/공통컴포넌트 드롭다운

### DIFF
--- a/src/assets/icons/arrow-filter-dropdown2.svg
+++ b/src/assets/icons/arrow-filter-dropdown2.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.25 9L12 15.75L18.75 9" stroke="#1B1B1B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
+import { useClickOutside } from '@/lib/utils/useClickOutside';
 
 interface DropdownOption {
   label: string;
@@ -10,23 +11,14 @@ interface DropdownProps {
   options: DropdownOption[];
   onSelect: (option: DropdownOption) => void;
   trigger: React.ReactNode;
+  dropdownClassName?: string;
 }
 
-export default function Dropdown({ options, onSelect, trigger }: DropdownProps) {
+export default function Dropdown({ options, onSelect, trigger, dropdownClassName = '' }: DropdownProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
+  useClickOutside(ref, () => setIsOpen(false));
 
   const handleSelect = (option: DropdownOption) => {
     option.onClick?.();
@@ -43,12 +35,14 @@ export default function Dropdown({ options, onSelect, trigger }: DropdownProps) 
       </button>
 
       {isOpen && (
-        <ul className='absolute right-4 rounded-xl border border-gray-300 bg-white whitespace-nowrap drop-shadow-sm'>
+        <ul
+          className={`absolute cursor-pointer rounded-xl border border-gray-300 bg-white whitespace-nowrap drop-shadow-sm ${dropdownClassName}`}
+        >
           {options.map((option, index) => (
             <li
               key={option.label}
               onClick={() => handleSelect(option)}
-              className={`text-md md:text-2lg h-[45px] w-[130px] cursor-pointer text-center leading-[45px] font-medium text-gray-900 hover:bg-gray-100 md:h-[56px] md:w-[160px] md:leading-[56px] ${
+              className={`text-md h-[45px] w-[130px] cursor-pointer text-center leading-[45px] font-medium text-gray-900 hover:bg-gray-100 md:h-[56px] md:w-[160px] md:text-lg md:leading-[56px] ${
                 index === 0 ? 'rounded-t-xl' : ''
               } ${index === options.length - 1 ? 'rounded-b-xl' : 'border-b border-gray-300'}`}
             >

--- a/src/lib/utils/useClickOutside.tsx
+++ b/src/lib/utils/useClickOutside.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export function useClickOutside(ref: React.RefObject<HTMLElement | null>, handler: () => void) {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, handler]);
+}

--- a/src/stories/FilterDropdown.stories.tsx
+++ b/src/stories/FilterDropdown.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import FilterDropdown from '@/components/FilterDropdown';
 import { Pretendard } from '@/font';
+import arrowFilterDropdown from '@/assets/icons/arrow-filter-dropdown.svg';
+import arrowFilterDropdown2 from '@/assets/icons/arrow-filter-dropdown2.svg';
 
 const meta: Meta<typeof FilterDropdown> = {
   title: 'FilterDropdown',
@@ -28,12 +30,31 @@ const statusOptions = [
   { label: '체험 완료' },
 ];
 
+const categoryOptions = [
+  { label: '문화 · 예술', onClick: () => {} },
+  { label: '식음료', onClick: () => {} },
+  { label: '스포츠', onClick: () => {} },
+  { label: '투어', onClick: () => {} },
+  { label: '관광', onClick: () => {} },
+  { label: '웰빙', onClick: () => {} },
+];
+
+const myActivityOptions = [
+  { label: '체험명1', onClick: () => {} },
+  { label: '체험명2', onClick: () => {} },
+  { label: '체험명3', onClick: () => {} },
+];
+
 export const StatusFilter: Story = {
   args: {
     label: '필터',
     options: statusOptions,
     onSelect: (option) => console.log(`선택된 상태 필터: ${option ? option.label : '전체'}`),
-    className: 'h-[53px] w-[90px] md:w-[160px]',
+    icon: arrowFilterDropdown,
+    buttonClassName:
+      'rounded-xl md:w-[160px] w-[90px] h-[53px] border border-green-100 px-4 py-2 font-medium whitespace-nowrap text-green-100 md:justify-between',
+    dropdownClassName: 'rounded-xl w-[90px] md:w-[160px] border border-gray-300 bg-white drop-shadow-sm',
+    optionClassName: 'text-md md:text-lg h-[41px] md:h-[62px] leading-[41px] md:leading-[62px]',
   },
 };
 
@@ -42,6 +63,44 @@ export const SortFilter: Story = {
     label: '가격',
     options: sortOptions,
     onSelect: (option) => console.log(`선택된 가격 정렬: ${option ? option.label : '전체'}`),
-    className: 'h-[53px] w-[100px] md:w-[145px]',
+    icon: arrowFilterDropdown,
+    buttonClassName:
+      'w-[90px] md:w-[120px] h-[53px] rounded-xl border border-green-100 px-4 py-2 font-medium whitespace-nowrap text-green-100 md:justify-between',
+    dropdownClassName: 'w-[90px] rounded-xl border md:w-[120px] border-gray-300 bg-white drop-shadow-sm',
+    optionClassName: 'text-md md:text-lg w-[90px] h-[41px] md:w-[120px] leading-[41px] md:h-[58px] md:leading-[58px]',
+  },
+};
+
+export const CategoryFilter: Story = {
+  args: {
+    label: '카테고리',
+    options: categoryOptions,
+    onSelect: (option) => console.log(`선택된 카테고리 정렬: ${option ? option.label : '전체'}`),
+    icon: arrowFilterDropdown2,
+    buttonClassName:
+      'border lg:w-[792px] w-[343px] md:w-[429px] text-black-100 border-gray-800 rounded-lg md:justify-between px-[15px] py-[15px]',
+    dropdownClassName: 'rounded-xl lg:w-[792px] w-[343px] md:w-[429px] border border-gray-300 bg-white drop-shadow-sm',
+    optionClassName:
+      'text-md md:text-lg h-[41px] lg:w-[792px] w-[343px] md:w-[429px] leading-[41px] md:h-[58px] md:leading-[58px]',
+    includeAllOption: false,
+    iconVisibleOnMobile: false,
+  },
+};
+
+export const MyActivityFilter: Story = {
+  args: {
+    label: '체험명',
+    options: myActivityOptions,
+    onSelect: (option) => console.log(`선택된 내 체험 정렬: ${option ? option.label : '전체'}`),
+    icon: arrowFilterDropdown2,
+    buttonClassName:
+      'h-[56px] lg:w-[792px] md:w-[429px] border text-black-100 w-[342px] border-gray-800 rounded-lg md:justify-between px-[15px] py-[12px] md:w-[429px] md:h-[56px] md:px-[15px] md:py-[15px]',
+    dropdownClassName:
+      'rounded-xl lg:w-[140px] md:w-[429px] lg:w-[792px]  w-[342px] border border-gray-300 bg-white drop-shadow-sm max-h-[200px] overflow-x-hidden overflow-y-auto',
+    optionClassName:
+      'text-md md:text-lg w-[342px] md:w-[429px] lg:w-[792px]  lg:w-[140px] h-[40px] leading-[40px] md:h-[50px] md:leading-[50px]',
+    includeAllOption: false,
+    iconVisibleOnMobile: false,
+    autoSelectFirstOption: true,
   },
 };


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -close #을 입력하면 이슈 번호가 나타납니다. -->
- close #60 

## :memo: Description
<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### FilterDropdown
**FilterDropdownProps**
- options 안에 label, onClick 함수 설정
- onClick, onSelect 차이
onSelect : 선택된 옵션을 전반적으로 처리하며 FilterDropdown을 사용하는 곳에서 onSelect를 정의해서 활용함(전역 상태 업데이트: API 호출, 필터 적용 등)
ex) onSelect={(option) => setFilter(option?.label || '전체')}
ex) onSelect={(option) => fetchData({ sort: option?.label })}
onClick : 각 옵션을 클릭했을 때 개별적으로 실행할 코드... 즉시 실행해야 함
- label : '가격', '필터' 같은 아무 값도 선택되지 않았을 때 보이는 label
- buttonClassName : label이 포함된 버튼으로 width, height, rounded, border, border-color, padding, font 등 설정 가능(폰트 색상 설정하지 않았을 경우 기본적으로 옵션을 선택 안 했을 때 연한 회색 처리해두었음)
- dropdownClassName : 버튼을 눌렀을 때 표시되는 전체 드롭다운의 스타일을 설정할 수 있음 (마찬가지로 width, height, border 등 사용자가 직접 설정 가능)
- optionClassName : 드롭다운의 각 옵션 스타일을 설정할 수 있음(마찬가지로 width, height, font 등 설정 가능)
- 각 드롭다운 호버했을 때 스타일 통일됨(배경색 bg-gray-100)
- icon : label이 포함된 버튼 안에 함께 표시되는 화살표 아이콘(arrow-filter-dropdown, arrow-filter-dropdown2 svg 파일 사용)
- includeAllOption : 기본으로 '전체' 옵션을 설정할지 말지를 정하며 true로 두면 '전체' 옵션을 설정하지 않아도 자동 추가되어 있고, 선택 시 아무것도 선택하지 않은 드롭다운 상태를 표시함(기본값 true)
- iconVisibleOnMobile : 필터나 가격 드롭다운에서 쓰이며 모바일 버전에서 width를 넘어가는 버그가 발생해 true로 설정 시 모바일 버전에서는 아이콘을 숨김 처리함(기본값 true)
- autoSelectFirstOption : 내 체험 예약 현황 페이지에 쓰이는 드롭다운을 위한 것으로 기본으로 첫 번째 옵션값이 바로 선택되도록 설정함(기본값 false)
- lib/utils/useClickOutSide 유틸 함수를 활용해 드롭다운을 연 상태에서 외부를 클릭하면 닫히도록 설정함
- 내 체험 예약 현황 페이지에 쓰이는 드롭다운의 Floating Label은 직접 배치해야 함
- 추후 value props가 추가될 수 있음
- 스토리북 구현 완료

⚠️ 자세한 코드는 스토리북 참조 바람
![스크린샷 2025-03-22 154341](https://github.com/user-attachments/assets/437ea15c-a984-4a92-b9e8-7799d8471159)

### Dropdown
**DropdownProps**
- options 안에 label, onClick 함수 설정
- 마찬가지로 onSelect, onClick 함수가 있음(위 설명 참조)
- trigger: 케밥 아이콘 또는 헤더의 프로필 이미지를 설정해 클릭했을 때 드롭다운을 표시하게 할 요소
- 기본적으로 드롭다운의 width, height, font 스타일, rounded, border, bg, 호버 스타일, 그림자는 고정되어 있음(통일하기 위함)
- dropdownClassName으로 드롭다운 위치 조정만 하면 됨(헤더랑 차이가 있어서 분리함)
- lib/utils/useClickOutSide 유틸 함수를 활용해 드롭다운을 연 상태에서 외부를 클릭하면 닫히도록 설정함
- 스토리북 구현 완료

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
