### PR TITLE
[#64] Feat/마이페이지 레이아웃

### DIFF
--- a/src/app/(with-nav-footer)/(mypage)/layout.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/layout.tsx
@@ -1,0 +1,12 @@
+import SideNavMenu from '@/components/SideNavMenu';
+
+export default function MyPageLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='flex justify-center px-4 pt-10'>
+      <div className='flex w-full max-w-[1140px] gap-10'>
+        <SideNavMenu />
+        <main className='flex-1'>{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/page.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <div> 내체험관리입니다</div>
+    </>
+  );
+}

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/reservation-dashboard/page.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/reservation-dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <div> 예약현황입니다</div>
+    </>
+  );
+}

--- a/src/app/(with-nav-footer)/(mypage)/my-reservations/page.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-reservations/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <div> 예약내역입니다</div>
+    </>
+  );
+}

--- a/src/components/SideNavMenu.tsx
+++ b/src/components/SideNavMenu.tsx
@@ -11,14 +11,12 @@ import MyActivities from '@/assets/icons/my-activities.svg';
 import MyReservationStatus from '@/assets/icons/my-activities-dashboard.svg';
 import EditIcon from '@/assets/icons/pencil.svg';
 
-const NAV_ITEMS = [
-  { name: '내 정보', path: '/my-page', icon: MyInfo },
-  { name: '예약 내역', path: '/my-reservations', icon: MyReservation },
-  { name: '내 체험 관리', path: '/my-activities', icon: MyActivities },
-  { name: '예약 현황', path: '/my-activities/[activityId]/reservation-dashboard', icon: MyReservationStatus },
-];
+interface SideNavMenuProps {
+  userId?: string;
+  activityId?: string;
+}
 
-const SideNavMenu = () => {
+const SideNavMenu = ({ userId, activityId }: SideNavMenuProps) => {
   const pathname = usePathname();
   const [previewImage, setPreviewImage] = useState<string | null>(null);
 
@@ -29,6 +27,17 @@ const SideNavMenu = () => {
       setPreviewImage(imageUrl);
     }
   };
+
+  const NAV_ITEMS = [
+    { name: '내 정보', path: '/my-page', icon: MyInfo },
+    { name: '예약 내역', path: '/my-reservations', icon: MyReservation },
+    { name: '내 체험 관리', path: `/my-activities/${userId}`, icon: MyActivities },
+    {
+      name: '예약 현황',
+      path: `/my-activities/${activityId}/reservation-dashboard`,
+      icon: MyReservationStatus,
+    },
+  ];
 
   return (
     <aside className='w-[251px] flex-none rounded-lg border border-gray-300 bg-white p-4 shadow-md md:w-[384px]'>


### PR DESCRIPTION
## :hash: Issue
- #64  
<!-- 이슈 번호를 작성해 주세요. -close #을 입력하면 이슈 번호가 나타납니다. -->

## :memo: Description
- SideNavMenu 컴포넌트를 마이페이지 전용 레이아웃에 적용
- 각 페이지별 사이드 네비게이션 위치 및 UI 시안 반영 완료
- SideNavMenu 내부의 userId / activityId는 동적 경로로 구성
- 현재는 로그인 기능 미완성 상태이므로, 테스트 시 임의 하드코딩한 값으로 동작 확인
- PR 시점에서는 완성 후 기준 구조만 유지

![내정보](https://github.com/user-attachments/assets/3d6d1cd5-932f-4ed3-b846-dedc7e7f0d4c)

![예약내역](https://github.com/user-attachments/assets/068847d7-4aaf-47e8-ba8b-9beae3e4ed52)

![내 체험관리](https://github.com/user-attachments/assets/efd191cd-8943-4233-8ee6-ce5342499e56)

![예약현황](https://github.com/user-attachments/assets/cccc6eae-03c1-4f4e-8274-f0d061b9cc69)

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [ ] (없음)
