### PR TITLE
[#66] feat/체험목록페이지 모든 체험

### DIFF
--- a/src/app/(with-nav-footer)/activities/_components/AllActivities.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/AllActivities.tsx
@@ -1,0 +1,107 @@
+'use client';
+import FilterDropdown from '@/components/FilterDropdown';
+import Category from './Category';
+import arrowFilterDropdown from '@/assets/icons/arrow-filter-dropdown.svg';
+import AllActivityItem from './AllActivityItem';
+import { useActivities } from '@/lib/hooks/useActivities';
+import { useState } from 'react';
+import Pagination from '@/components/Pagination';
+import useMediaQuery from '@/lib/utils/useMediaQuery';
+
+const sortOptions = [{ label: '가격 낮은 순' }, { label: '가격 높은 순' }];
+
+export default function AllActivities() {
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
+  const [selectedSort, setSelectedSort] = useState<'most_reviewed' | 'price_asc' | 'price_desc' | 'latest' | undefined>(
+    'latest',
+  );
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const isPC = useMediaQuery('(min-width: 1024px)');
+  const isTablet = useMediaQuery('(min-width: 768px) and (max-width: 1023px)');
+  const itemsPerPage = isPC ? 8 : isTablet ? 9 : 4;
+
+  const { data, isLoading, isError } = useActivities({
+    method: 'offset',
+    sort: selectedSort,
+    page: currentPage,
+    size: itemsPerPage,
+    category: selectedCategory,
+  });
+
+  const handleSortChange = (option: { label: string } | null) => {
+    if (option) {
+      const sortMap: Record<string, 'price_asc' | 'price_desc' | 'latest'> = {
+        '가격 낮은 순': 'price_asc',
+        '가격 높은 순': 'price_desc',
+      };
+      setSelectedSort(sortMap[option.label] || 'latest');
+    } else {
+      setSelectedSort('latest');
+    }
+    setCurrentPage(1);
+  };
+
+  const handleCategoryChange = (category: string | undefined) => {
+    setSelectedCategory(category);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+
+  return (
+    <>
+      <div className='mx-auto w-full max-w-[1200px] max-[1250px]:px-6 min-[1251px]:px-0'>
+        <div className='flex justify-between gap-[24px]'>
+          <div className='w-full min-w-[200px] overflow-visible md:w-full md:max-w-[760px] lg:w-full lg:max-w-[882px]'>
+            <Category selectedCategory={selectedCategory} onSelect={handleCategoryChange} />
+          </div>
+          <div>
+            <FilterDropdown
+              buttonClassName='w-[90px] md:w-[120px] h-[42px] md:h-[53px] rounded-xl border border-green-100 px-3 py-2 font-medium whitespace-nowrap text-green-100 md:justify-between'
+              dropdownClassName='w-[90px] rounded-xl border md:w-[120px] border-gray-300 bg-white drop-shadow-sm'
+              icon={arrowFilterDropdown}
+              label='가격'
+              onSelect={handleSortChange}
+              optionClassName='text-md md:text-lg w-[90px] h-[41px] md:w-[120px] leading-[41px] md:h-[58px] md:leading-[58px]'
+              options={sortOptions}
+              iconVisibleOnMobile={true}
+              includeAllOption={true}
+              selected={{
+                label:
+                  sortOptions.find(
+                    (option) =>
+                      option.label ===
+                      (selectedSort === 'price_asc'
+                        ? '가격 낮은 순'
+                        : selectedSort === 'price_desc'
+                          ? '가격 높은 순'
+                          : ''),
+                  )?.label || '가격',
+              }}
+            />
+          </div>
+        </div>
+        <section className='text-black-100 text-2lg mt-[35px] font-bold md:text-3xl'>🛼 모든 체험</section>
+        <div
+          className={`mt-[32px] grid max-h-[1024px] min-h-[715px] gap-x-[8px] gap-y-[20px] md:max-h-[1429px] md:gap-x-[16px] md:gap-y-[32px] lg:h-[922px] lg:gap-x-[24px] lg:gap-y-[48px] ${isPC ? 'grid-cols-4' : isTablet ? 'grid-cols-3' : 'grid-cols-2'}`}
+        >
+          {data?.activities?.map((activity) => <AllActivityItem key={activity.id} activity={activity} />)}
+        </div>
+        <div className='mt-[100px] flex justify-center'>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={Math.ceil((data?.totalCount || 0) / itemsPerPage)}
+            onChange={handlePageChange}
+            size={isPC || isTablet ? 'md' : 'sm'}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(with-nav-footer)/activities/_components/AllActivities.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/AllActivities.tsx
@@ -63,7 +63,7 @@ export default function AllActivities() {
           </div>
           <div>
             <FilterDropdown
-              buttonClassName='w-[90px] md:w-[120px] h-[42px] md:h-[53px] rounded-xl border border-green-100 px-3 py-2 font-medium whitespace-nowrap text-green-100 md:justify-between'
+              buttonClassName='w-[90px] md:w-[120px] h-[42px] md:h-[53px] rounded-xl border border-green-100 text-md md:text-lg px-3 py-2 font-medium whitespace-nowrap text-green-100 md:justify-between'
               dropdownClassName='w-[90px] rounded-xl border md:w-[120px] border-gray-300 bg-white drop-shadow-sm'
               icon={arrowFilterDropdown}
               label='가격'

--- a/src/app/(with-nav-footer)/activities/_components/AllActivityItem.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/AllActivityItem.tsx
@@ -1,0 +1,37 @@
+import { Activity } from '@/lib/types/activities';
+import Image from 'next/image';
+import starRating from '@/assets/icons/star-rating.svg';
+import Link from 'next/link';
+
+interface AllActivityItemProps {
+  activity: Activity;
+}
+
+export default function AllActivityItem({ activity }: AllActivityItemProps) {
+  return (
+    <div className='relative h-auto min-h-[293px] max-w-[348px]'>
+      <div className='relative aspect-[1/1] h-auto w-full max-w-[348px] min-w-[160px] cursor-pointer overflow-hidden rounded-3xl'>
+        <Link href={`/activities/${activity.id}`}>
+          <Image
+            fill
+            src={activity.bannerImageUrl}
+            className='object-cover transition-transform duration-300 ease-in-out will-change-transform hover:scale-105'
+            alt={`${activity.title} 배너 이미지`}
+          />
+        </Link>
+      </div>
+      <div className='mt-[16px] flex gap-1'>
+        <Image src={starRating} width={20} height={20} alt='별점' />
+        <p className='text-md text-black-100 font-medium'>{activity.rating.toFixed(1)}</p>
+        <p className='text-md text-gray-700'> ({activity.reviewCount})</p>
+      </div>
+      <div className='text-black-100 text-2lg mt-[10px] line-clamp-2 h-[52px] font-semibold break-keep md:h-[58px] md:text-2xl'>
+        {activity.title}
+      </div>
+      <div className='text-2lg text-black-100 mt-[5px] flex gap-1 font-bold md:mt-[15px] md:text-2xl'>
+        ₩ {activity.price.toLocaleString()}
+        <span className='text-lg font-medium text-gray-900 md:text-xl'>/ 인</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-nav-footer)/activities/_components/BestActivities.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/BestActivities.tsx
@@ -80,7 +80,7 @@ export default function BestActivities() {
       ) : (
         <div className='mt-[16px] flex gap-[16px] md:mt-[32px] md:gap-[24px]'>
           {visibleActivities?.map((activity) => (
-            <div key={activity.id} className='w-full'>
+            <div key={activity.id} className='w-full max-w-[384px]'>
               <BestActivityItem activity={activity} />
             </div>
           ))}

--- a/src/app/(with-nav-footer)/activities/_components/Category.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/Category.tsx
@@ -1,0 +1,111 @@
+'use client';
+import Button from '@/components/Button';
+import useMediaQuery from '@/lib/utils/useMediaQuery';
+import { useState, useEffect, useRef } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import type { Swiper as SwiperType } from 'swiper';
+import Image from 'next/image';
+import categoryArrowRight from '@/assets/icons/category-arrow-right.svg';
+import categoryArrowLeft from '@/assets/icons/category-arrow-left.svg';
+
+export default function Category({
+  selectedCategory,
+  onSelect,
+}: {
+  selectedCategory: string | undefined;
+  onSelect: (category: string | undefined) => void;
+}) {
+  const categories = ['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙'];
+  const [isEnd, setIsEnd] = useState(false);
+  const [isStart, setIsStart] = useState(true);
+  const swiperRef = useRef<SwiperType | null>(null);
+  const isMobileOrTablet = useMediaQuery('(max-width: 1024px)');
+
+  const handleCategoryClick = (category: string) => {
+    const newCategory = selectedCategory === category ? undefined : category;
+    onSelect(newCategory);
+  };
+
+  useEffect(() => {
+    if (!swiperRef.current) return;
+    setIsStart(swiperRef.current.isBeginning);
+    setIsEnd(swiperRef.current.isEnd);
+  }, [isMobileOrTablet]);
+
+  const handleArrowClick = () => {
+    if (!swiperRef.current) return;
+    swiperRef.current.slideTo(isEnd ? 0 : isStart ? categories.length - 1 : swiperRef.current.activeIndex + 1);
+  };
+
+  return (
+    <div className='relative flex w-full items-start md:w-full'>
+      {isMobileOrTablet ? (
+        <>
+          <div
+            className={`pointer-events-none absolute top-0 right-0 h-full w-[75px] bg-gradient-to-l from-white to-transparent transition-opacity ${
+              isEnd ? 'opacity-0' : 'opacity-100'
+            } z-10`}
+          />
+          <Swiper
+            spaceBetween={16}
+            slidesPerView={'auto'}
+            loop={false}
+            freeMode
+            className='z-0 lg:hidden'
+            onSwiper={(swiper) => {
+              swiperRef.current = swiper;
+              setIsStart(swiper.isBeginning);
+              setIsEnd(swiper.isEnd);
+            }}
+            onSlideChange={(swiper) => {
+              setIsStart(swiper.isBeginning);
+              setIsEnd(swiper.isEnd);
+            }}
+          >
+            {categories.map((category) => (
+              <SwiperSlide key={category} style={{ width: 'auto' }}>
+                <Button
+                  variant='outline'
+                  className={`md:text-2lg h-[42px] w-[80px] rounded-2xl text-center text-lg font-medium whitespace-nowrap md:h-[53px] md:w-[120px] ${
+                    selectedCategory == category ? 'bg-black-200 text-white' : ''
+                  }`}
+                  onClick={() => handleCategoryClick(category)}
+                >
+                  {category}
+                </Button>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+
+          <button
+            className='absolute top-1/2 right-0 z-20 -translate-y-1/2 cursor-pointer rounded-full'
+            onClick={handleArrowClick}
+          >
+            <Image
+              src={isEnd ? categoryArrowLeft : categoryArrowRight}
+              alt={isEnd ? 'Left Arrow' : 'Right Arrow'}
+              width={32}
+              height={32}
+            />
+          </button>
+        </>
+      ) : (
+        <div className='flex gap-[8px] overflow-x-auto md:gap-[14px] lg:gap-[20px]'>
+          {categories.map((category, index) => (
+            <Button
+              variant='outline'
+              className={`text-2lg h-[53px] w-[120px] rounded-2xl text-center font-medium whitespace-nowrap ${
+                selectedCategory === category ? 'bg-black-200 text-white' : ''
+              } ${isEnd && index === categories.length - 1 ? 'opacity-50' : ''}`}
+              key={category}
+              onClick={() => handleCategoryClick(category)}
+            >
+              {category}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(with-nav-footer)/activities/_components/Category.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/Category.tsx
@@ -84,7 +84,7 @@ export default function Category({
           >
             <Image
               src={isEnd ? categoryArrowLeft : categoryArrowRight}
-              alt={isEnd ? 'Left Arrow' : 'Right Arrow'}
+              alt={isEnd ? '좌측 화살표' : '우측 화살표'}
               width={32}
               height={32}
             />

--- a/src/app/(with-nav-footer)/activities/page.tsx
+++ b/src/app/(with-nav-footer)/activities/page.tsx
@@ -1,6 +1,7 @@
 import Banner from './_components/Banner';
-import BestActivities from './_components/BestActivities';
 import SearchBar from './_components/SearchBar';
+import BestActivities from './_components/BestActivities';
+import AllActivities from './_components/AllActivities';
 
 export default function Page() {
   return (
@@ -11,6 +12,9 @@ export default function Page() {
       </div>
       <div className='mt-[100px] md:mt-[158px]'>
         <BestActivities />
+      </div>
+      <div className='mt-[60px] mb-[20%]'>
+        <AllActivities />
       </div>
     </>
   );

--- a/src/assets/icons/category-arrow-left.svg
+++ b/src/assets/icons/category-arrow-left.svg
@@ -1,0 +1,19 @@
+<svg width="54" height="53" viewBox="0 0 54 53" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_30407_12686)">
+<circle cx="27" cy="24" r="16" transform="rotate(-180 27 24)" fill="white"/>
+<circle cx="27" cy="24" r="15.68" transform="rotate(-180 27 24)" stroke="#A1A1A1" stroke-width="0.64"/>
+</g>
+<path d="M30.2 30.4004L23.16 23.4004L29.6368 16.9604" stroke="#4B4B4B" stroke-width="1.92" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<filter id="filter0_d_30407_12686" x="0.76" y="0.32" width="52.48" height="52.48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2.56"/>
+<feGaussianBlur stdDeviation="5.12"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0666667 0 0 0 0 0.133333 0 0 0 0 0.0666667 0 0 0 0.05 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_30407_12686"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_30407_12686" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -5,6 +5,7 @@ import { useClickOutside } from '@/lib/utils/useClickOutside';
 
 interface FilterDropdownOption {
   label: string;
+  value?: string;
   onClick?: () => void;
 }
 
@@ -19,6 +20,7 @@ interface FilterDropdownProps {
   includeAllOption?: boolean;
   iconVisibleOnMobile?: boolean;
   autoSelectFirstOption?: boolean;
+  selected?: FilterDropdownOption | null;
 }
 
 export default function FilterDropdown({
@@ -32,13 +34,11 @@ export default function FilterDropdown({
   includeAllOption = false,
   iconVisibleOnMobile = false,
   autoSelectFirstOption = false,
+  selected = null,
 }: FilterDropdownProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [updatedOptions, setUpdatedOptions] = useState<FilterDropdownOption[]>([]);
-  const [selected, setSelected] = useState<FilterDropdownOption | null>(
-    autoSelectFirstOption ? updatedOptions[0] : null,
-  );
 
   useClickOutside(ref, () => setIsOpen(false));
 
@@ -46,15 +46,7 @@ export default function FilterDropdown({
     setUpdatedOptions(includeAllOption && !autoSelectFirstOption ? [{ label: '전체' }, ...options] : options);
   }, [includeAllOption, autoSelectFirstOption, options]);
 
-  useEffect(() => {
-    if (autoSelectFirstOption && updatedOptions.length > 0) {
-      setSelected(updatedOptions[0]);
-      onSelect(updatedOptions[0]);
-    }
-  }, [autoSelectFirstOption, updatedOptions, onSelect]);
-
   const handleSelect = (option: FilterDropdownOption) => {
-    setSelected(option.label === '전체' ? null : option);
     onSelect(option.label === '전체' ? null : option);
     setIsOpen(false);
   };


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -close #을 입력하면 이슈 번호가 나타납니다. -->
- close #66 

## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
- 모든 체험 컴포넌트는 최초 최신순으로 표시
- 페이지네이션 위치 고정을 위해 AllActivityItem grid 영역의 높이를 설정함
- 카테고리 버튼 선택하고, 페이지네이션 이동 시 카테고리 버튼 해제하거나 다른 카테고리 버튼 선택하면 1 페이지로 이동
- 가격 옵션 선택하고, 페이지네이션 이동 시 가격 옵션 해제하거나 다른 옵션 선택하면 1 페이지로 이동함
- 태블릿과 모바일 버전에서 카테고리 버튼을 좌우 스크롤할 수 있고, 화살표 버튼으로 나머지 카테고리 버튼을 표시할 수 있음
- 카테고리 필터, 가격 필터 동시에 적용 가능
- 반응형 구현 완료
- page.tsx에 임의로 mb-[20%] 설정하였음
- 추후 구현 사항
  - 태블릿과 모바일 사이즈에서 카테고리 필터 버튼 위에 표시되는 화살표 버튼의 동작이 화면 사이즈에 따라 적용될 때도 있고, 안 될 때도 있는 버그 발생(추후 아예 빼거나 수정할 예정) 


PC
![스크린샷 2025-03-26 175010](https://github.com/user-attachments/assets/0e968704-fd2c-4a9f-a53c-6ed705dac81a)
Tablet
![스크린샷 2025-03-26 175025](https://github.com/user-attachments/assets/4c6fe3e9-a67d-42b3-bb81-143f0cd7b2c9)
Mobile
![스크린샷 2025-03-26 175055](https://github.com/user-attachments/assets/a527b41f-7001-4adc-b798-c19d7bd4adc0)


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- FilterDropdown 파일에 추가 수정사항 있음
  - FilterDropdownOption의 value 옵셔널 prop 추가
  - FilterDropdownProps의 selected 옵셔널 prop 추가 
  - 기존에 useState로 관리하던 selected 코드를 제거함
