### PR TITLE
[#102] refactor/체험목록페이지 배너 슬라이드

### DIFF
--- a/src/app/(with-nav-footer)/activities/_components/Banner.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/Banner.tsx
@@ -1,18 +1,58 @@
+'use client';
 import Image from 'next/image';
-import banner from '@/assets/images/banner.jpg';
+import BannerSkeleton from './BannerSkeleton';
+import { useActivities } from '@/lib/hooks/useActivities';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Autoplay, EffectFade, Pagination } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/effect-fade';
+import 'swiper/css/pagination';
 
 export default function Banner() {
+  const { data, isLoading, isError } = useActivities({
+    method: 'offset',
+    sort: 'most_reviewed',
+  });
+
+  const bestActivitiesBanner = data?.activities?.slice(0, 4);
+
+  if (isLoading) return <BannerSkeleton />;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+
   return (
-    <section aria-label='글로벌 요리 체험 배너' className='relative h-[240px] w-full md:h-[550px]'>
-      <Image src={banner} alt='셰프와 함께하는 요리 체험 배너' fill className='object-cover' />
-      <div className='absolute inset-0 bg-gradient-to-r from-black/70 to-transparent/100' />
-      <div className='absolute inset-0 z-10 mx-auto my-[70px] max-w-[1200px] px-6 text-white md:my-[160px]'>
-        <h2 className='text-2xl font-bold md:text-[54px] md:leading-[60px]'>
-          셰프와 함께하는
-          <br /> 글로벌 요리 체험
-        </h2>
-        <p className='text-md my-[8px] font-semibold md:my-[20px] md:text-xl'>이달의 인기 체험 BEST 🔥</p>
-      </div>
+    <section aria-label='체험 목록 페이지 배너' className='relative h-[240px] w-full md:h-[550px]'>
+      <Swiper
+        spaceBetween={50}
+        slidesPerView={1}
+        effect='fade'
+        autoplay={{ delay: 3000, disableOnInteraction: false, pauseOnMouseEnter: false }}
+        loop={true}
+        modules={[Autoplay, EffectFade, Pagination]}
+        pagination={{ clickable: true }}
+        className='relative h-full w-full'
+      >
+        {bestActivitiesBanner?.map((activity) => (
+          <SwiperSlide key={activity.id}>
+            <div className='relative h-[550px] w-full'>
+              <Image
+                src={activity.bannerImageUrl}
+                alt={`${activity.title} 배너 이미지`}
+                fill
+                className='object-cover'
+              />
+            </div>
+            <div className='absolute inset-0 bg-gradient-to-r from-black/70 to-transparent/100' />
+            <div className='absolute inset-0 z-10 mx-auto my-[70px] max-w-[1200px] px-6 text-white md:my-[160px]'>
+              <h2 className='text-2xl font-bold md:text-[54px] md:leading-[60px]'>
+                {activity.title.split(' ').slice(0, 2).join(' ')}
+                <br />
+                {activity.title.split(' ').slice(2).join(' ')}
+              </h2>
+              <p className='text-md my-[8px] font-semibold md:my-[20px] md:text-xl'>이달의 인기 체험 BEST 🔥</p>
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
     </section>
   );
 }

--- a/src/app/(with-nav-footer)/activities/_components/BannerSkeleton.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/BannerSkeleton.tsx
@@ -1,0 +1,12 @@
+export default function BannerSkeleton() {
+  return (
+    <section className='relative h-[240px] w-full animate-pulse md:h-[550px]'>
+      <div className='relative h-[240px] w-full animate-pulse bg-gray-300 md:h-[550px]'></div>
+      <div className='absolute inset-0 bg-gradient-to-r from-black/70 to-transparent/100' />
+      <div className='absolute inset-0 z-10 mx-auto my-[70px] max-w-[1200px] px-6 text-white md:my-[160px]'>
+        <div className='mb-2 h-[64px] w-1/2 animate-pulse rounded bg-gray-300 md:h-[120px] md:w-1/3'></div>{' '}
+        <div className='my-[8px] h-[24px] w-1/5 animate-pulse rounded bg-gray-300 md:my-[20px] md:h-[32px]'></div>{' '}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(with-nav-footer)/activities/_components/BannerSkeleton.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/BannerSkeleton.tsx
@@ -1,11 +1,10 @@
 export default function BannerSkeleton() {
   return (
     <section className='relative h-[240px] w-full animate-pulse md:h-[550px]'>
-      <div className='relative h-[240px] w-full animate-pulse bg-gray-300 md:h-[550px]'></div>
       <div className='absolute inset-0 bg-gradient-to-r from-black/70 to-transparent/100' />
       <div className='absolute inset-0 z-10 mx-auto my-[70px] max-w-[1200px] px-6 text-white md:my-[160px]'>
-        <div className='mb-2 h-[64px] w-1/2 animate-pulse rounded bg-gray-300 md:h-[120px] md:w-1/3'></div>{' '}
-        <div className='my-[8px] h-[24px] w-1/5 animate-pulse rounded bg-gray-300 md:my-[20px] md:h-[32px]'></div>{' '}
+        <div className='mb-2 h-[64px] w-1/2 animate-pulse rounded bg-gray-300 md:h-[120px] md:w-1/3'></div>
+        <div className='my-[8px] h-[24px] w-1/5 animate-pulse rounded bg-gray-300 md:my-[20px] md:h-[32px]'></div>
       </div>
     </section>
   );


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. - close #을 입력하면 이슈 번호가 나타납니다. -->
- close #102 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
체험 목록 페이지의 배너를 기존 하드코딩 방식 대신 bannerImageUrl을 불러와 인기 체험(리뷰 많은 순) 4개의 배너 이미지를 렌더링합니다.
- 리뷰 많은 순(most_reviewed)로 인기 체험 4개의 bannerImageUrl을 불러옴
-  Swiper 라이브러리를 활용하여 fade-in, out 효과 적용
- 유저가 직접 클릭하거나 드래그하여 배너 이미지를 넘길 수 있음
- 반응형 구현 완료
- BannerSkeleton 컴포넌트를 만들어 로딩 처리
- split 메서드를 활용하여 공백을 기준으로 문자열을 잘라 2줄로 렌더링하도록 함

배너 fade-in, out

https://github.com/user-attachments/assets/30952d51-bcff-432b-9feb-0a58e08ad95a

배너 스켈레톤

https://github.com/user-attachments/assets/2aab0032-160a-4944-ba44-9d8a94009dcf


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
