### PR TITLE
[#103] feat/마이페이지 모바일레이아웃

### DIFF
--- a/src/app/(with-nav-footer)/(mypage)/layout.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/layout.tsx
@@ -4,7 +4,25 @@ import SideNavMenu from '@/components/SideNavMenu';
 import { ProfileImageProvider, useProfileImage } from '@/lib/contexts/ProfileImageContext';
 import { useMyActivities } from '@/lib/hooks/useMyActivities';
 import { useMyData } from '@/lib/hooks/useUsers';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+function MobileOnlyMenu() {
+  const { data: user } = useMyData();
+  const { data: activity } = useMyActivities();
+  const { setProfileImageUrl } = useProfileImage();
+
+  useEffect(() => {
+    if (user?.profileImageUrl) {
+      setProfileImageUrl(user.profileImageUrl);
+    }
+  }, [user, setProfileImageUrl]);
+
+  const activityId = useMemo(() => activity?.activities?.[0]?.id, [activity?.activities]);
+
+  return <SideNavMenu activityId={activityId} />;
+}
 
 function WithProfileImageContext({ children }: { children: React.ReactNode }) {
   const { data: user } = useMyData();
@@ -20,18 +38,52 @@ function WithProfileImageContext({ children }: { children: React.ReactNode }) {
   const activityId = useMemo(() => activity?.activities?.[0]?.id, [activity?.activities]);
 
   return (
-    <div className='flex w-full max-w-[1140px] gap-10'>
+    <div className='flex w-full max-w-[1140px] gap-4'>
       <SideNavMenu activityId={activityId} />
       <main className='flex-1'>{children}</main>
     </div>
   );
 }
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isMobile;
+}
+
 export default function MyPageLayout({ children }: { children: React.ReactNode }) {
+  const isMobile = useIsMobile();
+  const pathname = usePathname();
+  const showSideNavOnly = isMobile && pathname === '/mypage-nav';
+  const showMobileContentWithBack = isMobile && !showSideNavOnly;
+
   return (
     <div className='flex justify-center px-4 pt-10'>
       <ProfileImageProvider>
-        <WithProfileImageContext>{children}</WithProfileImageContext>
+        {showSideNavOnly ? (
+          <MobileOnlyMenu />
+        ) : showMobileContentWithBack ? (
+          <div className='w-full max-w-[680px]'>
+            <div className='mb-4'>
+              <Link href='/mypage-nav' className='text-sm text-gray-600 hover:underline'>
+                ← 마이페이지 홈으로 이동
+              </Link>
+            </div>
+            {children}
+          </div>
+        ) : (
+          <WithProfileImageContext>{children}</WithProfileImageContext>
+        )}
       </ProfileImageProvider>
     </div>
   );

--- a/src/app/(with-nav-footer)/(mypage)/layout.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/layout.tsx
@@ -5,7 +5,7 @@ import { ProfileImageProvider, useProfileImage } from '@/lib/contexts/ProfileIma
 import { useMyActivities } from '@/lib/hooks/useMyActivities';
 import { useMyData } from '@/lib/hooks/useUsers';
 import { useEffect, useMemo, useState } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 
 function MobileOnlyMenu() {

--- a/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/CancelReservationModal.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/CancelReservationModal.tsx
@@ -4,6 +4,8 @@ import Modal from '@/components/Modal';
 import Image from 'next/image';
 import checkIcon from '@/assets/icons/check-circle-filled.svg';
 import { useCancelMyReservation } from '@/lib/hooks/useMyReservation';
+import Button from '@/components/Button';
+import { toast } from 'react-toastify';
 
 type CancelReservationModalProps = {
   isOpen: boolean;
@@ -25,11 +27,13 @@ export default function CancelReservationModal({
   const handleCancel = () => {
     cancelReservation(reservationId, {
       onSuccess: () => {
+        toast.success('예약이 취소되었습니다.');
         onCancel();
         onClose();
       },
       onError: (error) => {
         console.error('예약 취소 실패:', error);
+        toast.error('예약 취소에 실패했어요.');
       },
     });
   };
@@ -42,19 +46,12 @@ export default function CancelReservationModal({
         </div>
         <p className='font-regular text-black-100 text-lg'>예약을 취소하시겠어요?</p>
         <div className='mt-4 flex w-full justify-center gap-2'>
-          <button
-            onClick={onClose}
-            aria-label='닫기 버튼'
-            className='text-black-200 border-black-200 min-w-[90px] rounded-md border bg-white px-4 py-2 text-lg font-bold'
-          >
-            아니요
-          </button>
-          <button
-            onClick={handleCancel}
-            className='bg-black-200 min-w-[90px] rounded-md px-4 py-2 text-lg font-bold text-white'
-          >
+          <Button variant='outline' onClick={onClose} className='!w-fit min-w-[90px] px-4 py-2 text-lg font-bold'>
+            아니오
+          </Button>
+          <Button variant='default' onClick={handleCancel} className='!w-fit min-w-[90px] px-4 py-2 text-lg font-bold'>
             취소하기
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>

--- a/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/MyReservationCard.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/MyReservationCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { ReservationWithActivity } from '@/lib/types/myReservation';
 import CancelReservationModal from './CancelReservationModal';
 import WriteReviewModal from './WriteReviewModal';
+import Button from '@/components/Button';
 
 const STATUS_LABEL_MAP = {
   pending: '예약 신청',
@@ -48,66 +49,67 @@ export default function MyReservationCard({ reservation }: MyReservationCardProp
 
   return (
     <>
-      <div className='flex w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm'>
-        {/* 썸네일 */}
-        <div className='h-[204px] w-[204px] flex-shrink-0 overflow-hidden rounded-l-lg'>
-          <Image
-            src={activity.bannerImageUrl}
-            alt={activity.title}
-            width={204}
-            height={204}
-            className='h-full w-full object-cover'
-          />
-        </div>
-
-        {/* 텍스트 정보 */}
-        <div className='flex flex-1 flex-col justify-between px-6 py-4'>
-          <div className='flex flex-col gap-4'>
-            <p className={`text-lg font-bold ${statusColorClass}`}>{statusLabel}</p>
-            <h3 className='text-black-200 text-xl font-bold'>{activity.title}</h3>
-            <p className='text-2lg text-black-200 font-regular'>{formattedDate}</p>
+      <div className='mb-6 w-full max-w-[792px] min-w-[344px] rounded-2xl shadow-md hover:bg-gray-100'>
+        <div className='flex'>
+          {/* 이미지 */}
+          <div className='relative aspect-[1/1] w-[128px] md:w-[156px] lg:w-[204px]'>
+            <Image
+              src={activity.bannerImageUrl}
+              alt={activity.title}
+              fill
+              sizes='(max-width: 768px) 128px, (max-width: 1024px) 156px, 204px'
+              className='absolute rounded-tl-2xl rounded-bl-2xl object-cover'
+            />
           </div>
 
-          <div className='flex items-end justify-between'>
-            <p className='text-black-200 text-2xl font-medium'>₩{totalPrice.toLocaleString()}</p>
+          {/* 텍스트 영역 */}
+          <div className='flex w-full flex-col px-[24px] py-[10px] md:py-[14px]'>
+            <div className='flex flex-col gap-1 leading-normal'>
+              <p className={`text-lg font-bold ${statusColorClass}`}>{statusLabel}</p>
+              <h3 className='text-black-200 md:text-2lg overflow-hidden text-lg font-bold text-ellipsis whitespace-nowrap lg:text-2xl'>
+                {activity.title}
+              </h3>
+              <p className='text-black-200 md:text-md lg:text-2lg font-regular text-xs'>{formattedDate}</p>
+            </div>
 
-            {/* 버튼 영역 */}
-            {status === 'pending' && (
-              <button
-                onClick={() => setIsCancelModalOpen(true)}
-                className='border-black-200 text-black-200 rounded-md border px-3 py-2 text-lg font-bold hover:bg-gray-300'
-              >
-                예약 취소
-              </button>
-            )}
+            <div className='mt-2 flex flex-row flex-wrap items-center justify-between gap-2'>
+              <p className='text-black-200 text-md font-medium md:text-xl'>₩ {totalPrice.toLocaleString()}</p>
 
-            {status === 'completed' && !reviewSubmitted && (
-              <button
-                onClick={() => setIsReviewModalOpen(true)}
-                className='bg-black-200 rounded-md px-3 py-2 text-lg font-bold text-white hover:bg-gray-900'
-              >
-                후기 작성
-              </button>
-            )}
+              {status === 'pending' && (
+                <Button
+                  variant='outline'
+                  onClick={() => setIsCancelModalOpen(true)}
+                  className='!w-fit px-4 py-2 text-xs font-bold md:text-sm'
+                >
+                  예약 취소
+                </Button>
+              )}
 
-            {status === 'completed' && reviewSubmitted && (
-              <span className='text-lg font-bold text-gray-400'>후기 작성 완료</span>
-            )}
+              {status === 'completed' && !reviewSubmitted && (
+                <Button
+                  variant='default'
+                  onClick={() => setIsReviewModalOpen(true)}
+                  className='!w-fit px-4 py-2 text-xs font-bold md:text-sm'
+                >
+                  후기 작성
+                </Button>
+              )}
+
+              {status === 'completed' && reviewSubmitted && (
+                <span className='text-xs font-bold text-green-100 md:text-sm'>후기 작성 완료</span>
+              )}
+            </div>
           </div>
         </div>
       </div>
 
-      {/* 예약 취소 모달 */}
+      {/* 모달 */}
       <CancelReservationModal
         isOpen={isCancelModalOpen}
         onClose={() => setIsCancelModalOpen(false)}
         reservationId={reservationId}
-        onCancel={() => {
-          setIsCancelModalOpen(false);
-        }}
+        onCancel={() => setIsCancelModalOpen(false)}
       />
-
-      {/* 후기 작성 모달 */}
       <WriteReviewModal
         isOpen={isReviewModalOpen}
         onClose={() => setIsReviewModalOpen(false)}

--- a/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/MyReservations.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/MyReservations.tsx
@@ -7,6 +7,7 @@ import MyReservationCard from './MyReservationCard';
 import FilterDropdown from '@/components/FilterDropdown';
 import arrowDownIcon from '@/assets/icons/arrow-filter-dropdown.svg';
 import emptyIcon from '@/assets/icons/empty.svg';
+import LoadingSpinner from '@/components/LoadingSpinner';
 
 const STATUS_LABEL_MAP = {
   pending: '예약 신청',
@@ -16,10 +17,10 @@ const STATUS_LABEL_MAP = {
   completed: '체험 완료',
 } as const;
 
-type Status = keyof typeof STATUS_LABEL_MAP | undefined; // all 제거, undefined로 사용
+type Status = keyof typeof STATUS_LABEL_MAP | undefined;
 
 const STATUS_OPTIONS = [
-  { label: '전체', value: undefined }, // all 제거하고 undefined로 사용
+  { label: '전체', value: undefined },
   ...Object.entries(STATUS_LABEL_MAP).map(([value, label]) => ({
     label,
     value,
@@ -47,12 +48,13 @@ export default function MyReservations() {
     return () => observer.disconnect();
   }, [fetchNextPage, hasNextPage]);
 
-  const selectedOption = STATUS_OPTIONS.find((opt) => opt.value === status);
+  const selectedOption =
+    status === undefined ? { label: '필터', value: undefined } : STATUS_OPTIONS.find((opt) => opt.value === status);
 
   return (
     <section className='w-full space-y-6'>
       <div className='flex items-center justify-between'>
-        <h1 className='text-black-200 text-2xl font-bold'>예약 내역</h1>
+        <h1 className='text-black-200 mb-0 text-2xl font-bold'>예약 내역</h1>
         <FilterDropdown
           label='필터'
           options={STATUS_OPTIONS}
@@ -60,13 +62,13 @@ export default function MyReservations() {
           onSelect={(option) => setStatus(option?.value as Status)}
           icon={arrowDownIcon}
           buttonClassName='min-w-[120px] justify-between  px-4 py-2 rounded-xl border border-green-100 font-medium whitespace-nowrap text-green-100'
-          dropdownClassName='min-w-[120px] border border-gray-300 bg-white drop-shadow-sm mt-2'
-          optionClassName='text-md text-lg px-4 py-2 text-lg font-medium text-gray-900 hover:bg-gray-100'
+          dropdownClassName='min-w-[120px] border border-gray-300 bg-white drop-shadow-sm rounded-xl'
+          optionClassName='text-md font-medium px-4 py-2  text-gray-900 hover:bg-gray-100'
         />
       </div>
 
       {isLoading ? (
-        <p className='text-center text-gray-400'>불러오는 중...</p>
+        <LoadingSpinner />
       ) : reservations.length === 0 ? (
         <div className='flex flex-col items-center justify-center py-20 text-center'>
           <Image src={emptyIcon} alt='예약 없음 아이콘' width={120} height={120} className='mb-6' />
@@ -74,7 +76,7 @@ export default function MyReservations() {
         </div>
       ) : (
         <>
-          <ul className='mx-auto w-full max-w-[680px] space-y-4 px-4'>
+          <ul className='w-full max-w-[680px] space-y-4 px-4'>
             {reservations.map((reservation) => (
               <li key={reservation.id}>
                 <MyReservationCard reservation={reservation} />

--- a/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/WriteReviewModal.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-reservations/_components/WriteReviewModal.tsx
@@ -3,11 +3,13 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import Modal from '@/components/Modal';
+import Button from '@/components/Button';
 import starIcon from '@/assets/icons/star.svg';
 import starFilledIcon from '@/assets/icons/star-hover.svg';
 import closeIcon from '@/assets/icons/close-fill.svg';
 import { ReservationWithActivity } from '@/lib/types/myReservation';
 import { useWriteReviewForReservation } from '@/lib/hooks/useMyReservation';
+import { toast } from 'react-toastify';
 
 type WriteReviewModalProps = {
   isOpen: boolean;
@@ -41,11 +43,11 @@ export default function WriteReviewModal({ isOpen, onClose, reservation }: Write
       },
       {
         onSuccess: () => {
-          alert('후기가 작성되었습니다.');
+          toast.success('후기가 작성되었습니다!');
           onClose();
         },
         onError: () => {
-          alert('후기 작성에 실패했습니다.');
+          toast.error('후기 작성에 실패했습니다.');
         },
       },
     );
@@ -110,13 +112,14 @@ export default function WriteReviewModal({ isOpen, onClose, reservation }: Write
         />
 
         {/* 버튼 */}
-        <button
+        <Button
+          variant='default'
           onClick={handleSubmit}
           disabled={isPending}
-          className='bg-black-200 mt-4 w-full rounded-md py-3 font-bold text-white hover:bg-gray-900 disabled:bg-gray-300'
+          className='mt-4 w-full py-3 text-lg font-bold'
         >
           {isPending ? '작성 중...' : '작성하기'}
-        </button>
+        </Button>
       </div>
     </Modal>
   );

--- a/src/app/(with-nav-footer)/mypage-nav/page.tsx
+++ b/src/app/(with-nav-footer)/mypage-nav/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import SideNavMenu from '@/components/SideNavMenu';
+import { useMyActivities } from '@/lib/hooks/useMyActivities';
+import { useMyData } from '@/lib/hooks/useUsers';
+import { useEffect, useMemo } from 'react';
+import { ProfileImageProvider, useProfileImage } from '@/lib/contexts/ProfileImageContext';
+import { useRouter, usePathname } from 'next/navigation';
+
+function MobileSideNavWrapper() {
+  const { data: user } = useMyData();
+  const { data: activity } = useMyActivities();
+  const { setProfileImageUrl } = useProfileImage();
+
+  const activityId = useMemo(() => activity?.activities?.[0]?.id, [activity?.activities]);
+
+  useEffect(() => {
+    if (user?.profileImageUrl) {
+      setProfileImageUrl(user.profileImageUrl);
+    }
+  }, [user, setProfileImageUrl]);
+
+  return <SideNavMenu activityId={activityId} />;
+}
+
+export default function Page() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleResize = () => {
+      const isDesktop = window.innerWidth > 768;
+      const isMobileNavPage = pathname === '/mypage-nav';
+
+      if (isDesktop && isMobileNavPage) {
+        router.replace('/my-page');
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [pathname, router]);
+
+  return (
+    <div className='px-4 pt-10'>
+      <ProfileImageProvider>
+        <MobileSideNavWrapper />
+      </ProfileImageProvider>
+    </div>
+  );
+}

--- a/src/components/SideNavMenu.tsx
+++ b/src/components/SideNavMenu.tsx
@@ -59,16 +59,18 @@ const SideNavMenu = ({ activityId }: SideNavMenuProps) => {
   ];
 
   return (
-    <aside className='h-[432px] w-[251px] flex-none rounded-lg border border-gray-300 bg-white p-4 shadow-md md:w-[384px]'>
-      <div className='relative flex flex-col items-center gap-4'>
-        <ProfileImage size='large' src={previewImage || profileImageUrl || undefined} />
-        <label
-          className='hover:bg-green-10 absolute right-7 bottom-0 flex h-11 w-11 cursor-pointer items-center justify-center rounded-full bg-green-100 transition md:right-24'
-          aria-label='프로필 수정'
-        >
-          <Image src={EditIcon} alt='프로필 수정' width={24} height={24} />
-          <input type='file' accept='image/*' className='hidden' onChange={handleFileChange} />
-        </label>
+    <aside className='mx-auto h-[432px] w-[384px] flex-none rounded-lg border border-gray-300 bg-white p-4 shadow-md sm:w-[251px] md:w-[344px]'>
+      <div className='flex justify-center'>
+        <div className='relative w-fit'>
+          <ProfileImage size='large' src={previewImage || profileImageUrl || undefined} />
+          <label
+            className='hover:bg-green-10 absolute -right-0 -bottom-0 flex h-11 w-11 cursor-pointer items-center justify-center rounded-full bg-green-100 transition'
+            aria-label='프로필 수정'
+          >
+            <Image src={EditIcon} alt='프로필 수정' width={24} height={24} />
+            <input type='file' accept='image/*' className='hidden' onChange={handleFileChange} />
+          </label>
+        </div>
       </div>
       <nav className='mt-6'>
         <ul className='flex flex-col gap-1'>
@@ -85,7 +87,7 @@ const SideNavMenu = ({ activityId }: SideNavMenuProps) => {
                 <Link
                   href={item.path}
                   className={`group flex w-full items-center gap-3 rounded-lg p-3 text-lg font-bold transition ${
-                    isActive ? 'text-black-200 bg-gray-200' : 'hover:bg-green-10 hover:text-black-200 text-gray-700'
+                    isActive ? 'text-black-200 bg-white' : 'hover:bg-green-10 hover:text-black-200 text-gray-700'
                   }`}
                 >
                   <Image


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. - close #을 입력하면 이슈 번호가 나타납니다. -->
-close #103 

## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
-  모바일 환경 대응을 위해 /mypage-nav 페이지를 생성하여 사이드 네브바를 단독 화면에서 렌더링하도록 분리
- 모바일에서는 사이드 네브바가 사라지고, 각 페이지 상단에 "마이페이지 홈으로 이동" 버튼을 추가해 /mypage-nav로 이동 가능하게 구현
- layout.tsx에서 모바일/데스크탑 환경을 감지해 사이드 네브바 렌더링 방식을 조건부 분기
- MyReservationCard 컴포넌트에 반응형 대응 적용 (데스크탑/태블릿/모바일 크기별 사이즈 조절)
- 기존의 button 태그 대신 공통 Button 컴포넌트 사용으로 일관된 스타일 및 재사용성 확보
- 기 작성/예약 취소 완료 시 React Toastify를 활용하여 사용자에게 동작 결과 알림 처리
- FilterDropdown 드롭다운 UI 개선: 옵션 스타일 둥글게, 선택 영역 시각적으로 개선
- 로딩 시 loading spinner 사용으로 변경 

- 모바일에서 sidenavmenu 사라지고 홈으로 이동 구현 
![image](https://github.com/user-attachments/assets/5a22485e-40cb-42d3-8eea-7ef7d1062429)

- 홈으로 이동시 mypage-nav 페이지로 이동
![image](https://github.com/user-attachments/assets/316884e8-3f93-41b7-8f48-5c0c9576cb40)



## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] Base Branch 확인
- [ ] 커밋 메시지 컨벤션 준수
- [ ] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

