### PR TITLE
[#111] feat/공통컴포넌트 404, 에러 처리

### DIFF
--- a/src/app/(with-nav-footer)/activities/_components/ActivityList.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/ActivityList.tsx
@@ -12,6 +12,7 @@ import Pagination from '@/components/Pagination';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import leftArrow from '@/assets/icons/left-arrow.svg';
 import empty from '@/assets/icons/empty.svg';
+import RetryError from '@/components/RetryError';
 
 export default function ActivityList() {
   const router = useRouter();
@@ -22,7 +23,7 @@ export default function ActivityList() {
   const isTablet = useMediaQuery('(min-width: 768px) and (max-width: 1023px)');
   const itemsPerPage = isPC ? 8 : isTablet ? 9 : 4;
 
-  const { data, isLoading, isError } = useActivities({
+  const { data, isLoading, isError, refetch } = useActivities({
     method: 'offset',
     keyword: searchTerm || undefined,
     page: currentPage,
@@ -62,7 +63,7 @@ export default function ActivityList() {
   }, [searchParams]);
 
   if (isLoading) return <LoadingSpinner />;
-  if (isError) return <div>에러가 발생했습니다.</div>;
+  if (isError) return <RetryError onRetry={refetch} className='py-40' />;
 
   return (
     <>

--- a/src/app/(with-nav-footer)/activities/_components/Banner.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/Banner.tsx
@@ -7,9 +7,10 @@ import { Autoplay, EffectFade, Pagination } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/effect-fade';
 import 'swiper/css/pagination';
+import RetryError from '@/components/RetryError';
 
 export default function Banner() {
-  const { data, isLoading, isError } = useActivities({
+  const { data, isLoading, isError, refetch } = useActivities({
     method: 'offset',
     sort: 'most_reviewed',
   });
@@ -17,7 +18,7 @@ export default function Banner() {
   const bestActivitiesBanner = data?.activities?.slice(0, 4);
 
   if (isLoading) return <BannerSkeleton />;
-  if (isError) return <div>에러가 발생했습니다.</div>;
+  if (isError) return <RetryError onRetry={refetch} className='py-40' />;
 
   return (
     <section aria-label='체험 목록 페이지 배너' className='relative h-[240px] w-full md:h-[550px]'>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Header from '@/components/Header';
+import Image from 'next/image';
+import noData from '@/assets/icons/No-data.svg';
+import Button from '@/components/Button';
+import Link from 'next/link';
+import Footer from '@/components/Footer';
+
+export default function NotFound() {
+  return (
+    <>
+      <Header />
+      <div className='flex h-screen flex-col items-center justify-center gap-[30px]'>
+        <Image className='h-[136px] w-[136px]' alt='404' src={noData} priority />
+        <div className='text-center'>
+          <h1 className='text-xl font-bold text-gray-800 md:text-2xl'>404</h1>
+          <p className='mt-2 text-gray-800 md:text-lg'>잘못된 주소 또는 없는 페이지입니다.</p>
+        </div>
+        <Link href='/'>
+          <Button className='text-md px-6 py-2 md:text-lg'>홈으로 돌아가기</Button>
+        </Link>
+      </div>
+      <Footer />
+    </>
+  );
+}

--- a/src/components/RetryError.tsx
+++ b/src/components/RetryError.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+import noData from '@/assets/icons/No-data.svg';
+import Button from '@/components/Button';
+import Link from 'next/link';
+
+export default function RetryError({ onRetry, className = '' }: { onRetry: () => void; className?: string }) {
+  return (
+    <div className={`flex flex-col items-center justify-center gap-10 whitespace-nowrap ${className}`}>
+      <Image className='h-[136px] w-[136px]' alt='에러' src={noData} priority />
+      <div className='text-center'>
+        <h1 className='text-xl font-bold text-gray-800 md:text-2xl'>에러가 발생했습니다.</h1>
+        <p className='mt-2 text-gray-800 md:text-lg'>잠시 후에 다시 시도해 주세요.</p>
+      </div>
+      <div className='flex gap-4'>
+        <Button variant={'outline'} onClick={onRetry} className='text-md px-6 py-2 md:text-lg'>
+          다시 시도하기
+        </Button>
+        <Link href='/'>
+          <Button className='text-md px-6 py-2 md:text-lg'>홈으로 돌아가기</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. - close #을 입력하면 이슈 번호가 나타납니다. -->
- close #111 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
404 페이지와 에러 처리를 위한 RetryError 컴포넌트 작업 내용입니다.
- 404 페이지는 app/not-found.tsx 파일을 생성하여 잘못된 주소에 접속했을 때 렌더링하였으며 "홈으로 돌아가기" 버튼 클릭 시 랜딩 페이지("/")로 이동함
- RetryError 컴포넌트의 onRetry, className prop이 있으며 onRetry에는 리액트 쿼리 refetch를 연결해 데이터를 다시 불러오도록 연결하고, className은 위아래 여백을 위한 용도(마이 페이지는 py-10, 체험 목록, 체험 상세 페이지는 py-40으로 설정함)
- "다시 시도하기" 버튼 클릭 시 부분적으로 새로고침되며 데이터를 다시 불러오고, "홈으로 돌아가기" 버튼 클릭 시 랜딩 페이지("/")로 이동함
- No-data 이미지 파일명 소문자로 바꿔야 하고, 이미지 배경색 변경 고려
- 반응형 구현 완료
- 현재 체험 목록 페이지의 Banner 컴포넌트와 ActivityList 컴포넌트에만 RetryError 컴포넌트로 에러 처리 적용하였음

``` tsx
  if (isError) return <RetryError onRetry={refetch} className='py-40' />;
```

![스크린샷 2025-04-03 100722](https://github.com/user-attachments/assets/254e9923-e0ee-4727-ac9b-bb696bbb34de)
![스크린샷 2025-04-03 100618](https://github.com/user-attachments/assets/f42554de-77b9-4821-aa6a-71d7e2a88966)
![스크린샷 2025-04-03 100654](https://github.com/user-attachments/assets/7cc4e680-49cb-47df-8b4e-8deeb69f10f8)

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
