### PR TITLE
[#137] refactor/체험목록페이지 2차 리팩토링

### DIFF
--- a/src/app/(with-nav-footer)/(mypage)/layout.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/layout.tsx
@@ -16,9 +16,7 @@ function WithProfileImageContext({ children }: { children: React.ReactNode }) {
   const activityId = useProfileInit();
   return (
     <div className='flex w-full max-w-[1140px] gap-4'>
-      <div className='mt-10'>
-        <SideNavMenu activityId={activityId} />
-      </div>
+      <SideNavMenu activityId={activityId} />
       <main className='flex-1'>{children}</main>
     </div>
   );

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/edit-activities/_components/EditActivities.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/edit-activities/_components/EditActivities.tsx
@@ -4,8 +4,10 @@ import ActivityForm from '../../../_components/ActivityForm';
 import { useUpdateActivity } from '@/lib/hooks/useMyActivities';
 import { useActivityDetail } from '@/lib/hooks/useActivities';
 import { toast } from 'react-toastify';
+import { useRouter } from 'next/navigation';
 
 export default function EditActivityPage({ activityId }: { activityId: number }) {
+  const router = useRouter();
   const { data: activity } = useActivityDetail(activityId);
   const { mutate: updateActivity, isPending } = useUpdateActivity(activityId);
 
@@ -51,7 +53,9 @@ export default function EditActivityPage({ activityId }: { activityId: number })
           updateActivity(transformedData.data, {
             onSuccess: () => {
               toast.success('수정이 완료되었습니다!');
-              window.location.href = '/my-activities';
+              setTimeout(() => {
+                router.push('/my-activities');
+              }, 2000);
             },
             onError: () => {
               toast.error('수정에 실패했습니다.');

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/edit-activities/_components/EditActivities.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/[id]/edit-activities/_components/EditActivities.tsx
@@ -4,10 +4,8 @@ import ActivityForm from '../../../_components/ActivityForm';
 import { useUpdateActivity } from '@/lib/hooks/useMyActivities';
 import { useActivityDetail } from '@/lib/hooks/useActivities';
 import { toast } from 'react-toastify';
-import { useRouter } from 'next/navigation';
 
 export default function EditActivityPage({ activityId }: { activityId: number }) {
-  const router = useRouter();
   const { data: activity } = useActivityDetail(activityId);
   const { mutate: updateActivity, isPending } = useUpdateActivity(activityId);
 
@@ -54,7 +52,7 @@ export default function EditActivityPage({ activityId }: { activityId: number })
             onSuccess: () => {
               toast.success('수정이 완료되었습니다!');
               setTimeout(() => {
-                router.push('/my-activities');
+                window.location.href = '/my-activities';
               }, 2000);
             },
             onError: () => {

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/_components/SchduleList.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/_components/SchduleList.tsx
@@ -4,6 +4,8 @@ import DatePicker from 'react-datepicker';
 import { DatepickerStyles } from './DatepickerStyles';
 import 'react-datepicker/dist/react-datepicker.css';
 import Button from '@/components/Button';
+import Image from 'next/image';
+import calendar from '@/assets/icons/calendar.svg';
 
 interface ScheduleListProps {
   value: CreateSchedule[];
@@ -52,13 +54,17 @@ export default function ScheduleList({ value, onChange, error }: ScheduleListPro
         <div className='flex items-center gap-1 md:gap-4'>
           <div className='Datepickerstyles flex w-full max-w-[379px] min-w-[110px] flex-col'>
             <label className='text-md mb-1'>날짜</label>
-            <DatePicker
-              selected={temp.date}
-              onChange={(date) => setTemp({ ...temp, date })}
-              className='h-[48px] w-full max-w-[379px] min-w-[110px] rounded border px-2 md:px-4'
-              placeholderText='YY/MM/DD'
-              dateFormat='yy/MM/dd'
-            />
+            <div className='flex h-[48px] w-full max-w-[379px] items-center justify-between rounded border px-2 md:px-4'>
+              <DatePicker
+                selected={temp.date}
+                onChange={(date) => setTemp({ ...temp, date })}
+                className='w-full'
+                placeholderText='YY/MM/DD'
+                dateFormat='yy/MM/dd'
+                popperPlacement='bottom-end'
+              />
+              <Image src={calendar} width={20} height={20} alt='달력' className='ml-2 hidden md:block' />
+            </div>
           </div>
           <div className='flex w-full max-w-[140px] min-w-[79px] flex-col'>
             <label className='text-md mb-1'>시작 시간</label>

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/add-activities/_components/AddActivities.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/add-activities/_components/AddActivities.tsx
@@ -1,13 +1,11 @@
 'use client';
 
 import { toast } from 'react-toastify';
-import { useRouter } from 'next/navigation';
 import ActivityForm from '../../_components/ActivityForm';
 import { useCreateActivity } from '@/lib/hooks/useActivities';
 import { CreateActivityParams } from '@/lib/types/activities';
 
 export default function CreateActivityPage() {
-  const router = useRouter();
   const { mutate: createActivity, isPending } = useCreateActivity();
 
   const handleSubmit = (data: CreateActivityParams) => {
@@ -15,7 +13,7 @@ export default function CreateActivityPage() {
       onSuccess: () => {
         toast.success('체험이 등록되었습니다!');
         setTimeout(() => {
-          router.push('/my-activities');
+          window.location.href = '/my-activities';
         }, 2000);
       },
       onError: () => {

--- a/src/app/(with-nav-footer)/(mypage)/my-activities/add-activities/_components/AddActivities.tsx
+++ b/src/app/(with-nav-footer)/(mypage)/my-activities/add-activities/_components/AddActivities.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { toast } from 'react-toastify';
+import { useRouter } from 'next/navigation';
 import ActivityForm from '../../_components/ActivityForm';
 import { useCreateActivity } from '@/lib/hooks/useActivities';
 import { CreateActivityParams } from '@/lib/types/activities';
 
 export default function CreateActivityPage() {
+  const router = useRouter();
   const { mutate: createActivity, isPending } = useCreateActivity();
 
   const handleSubmit = (data: CreateActivityParams) => {
     createActivity(data, {
       onSuccess: () => {
         toast.success('체험이 등록되었습니다!');
-        window.location.href = '/my-activities';
+        setTimeout(() => {
+          router.push('/my-activities');
+        }, 2000);
       },
       onError: () => {
         toast.error('체험 등록에 실패했습니다.');

--- a/src/app/(with-nav-footer)/activities/_components/AllActivityItem.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/AllActivityItem.tsx
@@ -9,7 +9,7 @@ interface AllActivityItemProps {
 
 export default function AllActivityItem({ activity }: AllActivityItemProps) {
   return (
-    <article className='relative h-auto min-h-[293px] max-w-[348px]'>
+    <article className='group relative h-auto min-h-[293px] max-w-[348px]'>
       <Link href={`/activities/${activity.id}`}>
         <div className='relative aspect-[1/1] h-auto w-full max-w-[348px] min-w-[160px] cursor-pointer overflow-hidden rounded-3xl'>
           <Image
@@ -17,22 +17,22 @@ export default function AllActivityItem({ activity }: AllActivityItemProps) {
             alt={`${activity.title} 배너 이미지`}
             fill
             sizes='(max-width: 768px) 100vw, 348px'
-            className='object-cover transition-transform duration-300 ease-in-out will-change-transform hover:scale-105'
+            className='object-cover transition-transform duration-300 ease-in-out will-change-transform group-hover:scale-105'
           />
         </div>
+        <div className='mt-[16px] flex gap-1'>
+          <Image src={starRating} className='h-[18px] w-[18px]' alt='별점 아이콘' />
+          <p className='text-md text-black-100 leading-[18px] font-medium'>{activity.rating.toFixed(1)}</p>
+          <p className='text-md leading-[18px] text-gray-700'> ({activity.reviewCount})</p>
+        </div>
+        <div className='text-black-100 text-2lg mt-[10px] line-clamp-2 h-[52px] font-semibold break-keep md:h-[58px] md:text-2xl'>
+          {activity.title}
+        </div>
+        <div className='text-2lg text-black-100 mt-[5px] flex gap-1 font-semibold md:mt-[15px] md:text-xl'>
+          ₩ {activity.price.toLocaleString()}
+          <span className='text-lg leading-[26px] font-medium text-gray-700 md:leading-[32px]'>/ 인</span>
+        </div>
       </Link>
-      <div className='mt-[16px] flex gap-1'>
-        <Image src={starRating} className='h-[18px] w-[18px]' alt='별점 아이콘' />
-        <p className='text-md text-black-100 leading-[18px] font-medium'>{activity.rating.toFixed(1)}</p>
-        <p className='text-md leading-[18px] text-gray-700'> ({activity.reviewCount})</p>
-      </div>
-      <div className='text-black-100 text-2lg mt-[10px] line-clamp-2 h-[52px] font-semibold break-keep md:h-[58px] md:text-2xl'>
-        {activity.title}
-      </div>
-      <div className='text-2lg text-black-100 mt-[5px] flex gap-1 font-semibold md:mt-[15px] md:text-xl'>
-        ₩ {activity.price.toLocaleString()}
-        <span className='text-lg leading-[26px] font-medium text-gray-700 md:leading-[32px]'>/ 인</span>
-      </div>
     </article>
   );
 }

--- a/src/app/(with-nav-footer)/activities/_components/BestActivitiesBanner.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/BestActivitiesBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import BestActivitiesBannerSkeleton from './BestActivitiesBannerSkeleton';
 import RetryError from '@/components/RetryError';
 import { useActivities } from '@/lib/hooks/useActivities';
@@ -42,28 +43,30 @@ export default function BestActivitiesBanner() {
 
           return (
             <SwiperSlide key={activity.id}>
-              <div className='relative h-[550px] w-full'>
-                <Image
-                  src={activity.bannerImageUrl}
-                  alt={`${activity.title} 배너 이미지`}
-                  fill
-                  priority={index === 0}
-                  sizes='100vw'
-                  quality={100}
-                  className='object-cover'
-                />
-              </div>
-              <div className='absolute inset-0 bg-gradient-to-r from-black/70 to-transparent' />
-              <div className='absolute inset-0 z-10 mx-auto my-[70px] max-w-[1200px] px-6 text-white md:my-[160px]'>
-                <h2 className='text-2xl font-bold text-white md:text-[54px] md:leading-[60px]'>
-                  {firstLine}
-                  <br />
-                  {secondLine}
-                </h2>
-                <p className='text-md my-[8px] font-semibold text-white md:my-[20px] md:text-xl'>
-                  이달의 인기 체험 BEST 🔥
-                </p>
-              </div>
+              <Link href={`/activities/${activity.id}`}>
+                <div className='relative h-[550px] w-full'>
+                  <Image
+                    src={activity.bannerImageUrl}
+                    alt={`${activity.title} 배너 이미지`}
+                    fill
+                    priority={index === 0}
+                    sizes='100vw'
+                    quality={100}
+                    className='object-cover'
+                  />
+                </div>
+                <div className='absolute inset-0 bg-gradient-to-r from-black/70 to-transparent' />
+                <div className='absolute inset-0 z-10 mx-auto my-[70px] max-w-[1200px] px-6 text-white md:my-[160px]'>
+                  <h2 className='text-2xl font-bold text-white md:text-[54px] md:leading-[60px]'>
+                    {firstLine}
+                    <br />
+                    {secondLine}
+                  </h2>
+                  <p className='text-md my-[8px] font-semibold text-white md:my-[20px] md:text-xl'>
+                    이달의 인기 체험 BEST 🔥
+                  </p>
+                </div>
+              </Link>
             </SwiperSlide>
           );
         })}

--- a/src/app/(with-nav-footer)/activities/_components/Category.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/Category.tsx
@@ -95,7 +95,7 @@ export default function Category({
           {CATEGORIES.map((category, index) => (
             <Button
               variant='outline'
-              className={`text-2lg h-[53px] w-[120px] rounded-2xl text-center font-medium whitespace-nowrap ${
+              className={`text-2lg h-[53px] w-[120px] rounded-2xl bg-white text-center font-medium whitespace-nowrap ${
                 selectedCategory === category ? 'bg-black-200 text-white' : ''
               } ${isEnd && index === CATEGORIES.length - 1 ? 'opacity-50' : ''}`}
               key={category}

--- a/src/app/(with-nav-footer)/activities/_components/Category.tsx
+++ b/src/app/(with-nav-footer)/activities/_components/Category.tsx
@@ -68,7 +68,7 @@ export default function Category({
               <SwiperSlide key={category} style={{ width: 'auto' }}>
                 <Button
                   variant='outline'
-                  className={`md:text-2lg text-md h-[42px] w-[80px] rounded-2xl text-center font-medium whitespace-nowrap md:h-[53px] md:w-[120px] ${
+                  className={`md:text-2lg text-md h-[42px] w-[80px] rounded-2xl bg-white text-center font-medium whitespace-nowrap md:h-[53px] md:w-[120px] ${
                     selectedCategory == category ? 'bg-black-200 text-white' : ''
                   }`}
                   onClick={() => handleCategoryClick(category)}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,7 +28,6 @@
   --text-xs: 12px;
   --text-xs--line-height: 20px;
 
-  /* 피그마에 있는 순서대로 */
   /* Black */
   --color-black-100: #1b1b1b;
   --color-black-200: #112211;
@@ -84,6 +83,16 @@
 
 .animate-glow {
   animation: glow-effect 4s infinite ease-in-out;
+}
+
+.custom-toast {
+  width: var(--toastify-toast-width);
+  max-width: var(--toastify-toast-max-width);
+}
+
+:root {
+  --toastify-toast-width: 320px;
+  --toastify-toast-max-width: 320px;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,14 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 export const metadata: Metadata = {
-  title: 'GlobalNomad',
-  description: '여러 종류의 체험을 예약하세요',
+  metadataBase: new URL('https://globalnomad-9a8d.vercel.app/'),
+  title: 'GlobalNomad - 체험을 한 곳에서 간편하게',
+  description: '다채로운 체험을 간편하게 예약하고, 잊지 못할 추억을 만들어 보세요!',
+  openGraph: {
+    title: 'GlobalNomad - 체험을 한 곳에서 간편하게',
+    description: '다채로운 체험을 간편하게 예약하고, 잊지 못할 추억을 만들어 보세요!',
+    images: ['/thumbnail.jpg'],
+  },
 };
 
 export default function RootLayout({
@@ -19,7 +25,12 @@ export default function RootLayout({
     <html lang='ko'>
       <body className={`${Pretendard.className} bg-gray-100`}>
         <QueryClientProvider>{children}</QueryClientProvider>
-        <ToastContainer position='top-right' style={{ marginTop: '70px' }} />
+        <ToastContainer
+          position='top-right'
+          style={{ marginTop: '70px' }}
+          toastClassName='custom-toast'
+          autoClose={1500}
+        />
       </body>
     </html>
   );

--- a/src/components/SideNavMenu.tsx
+++ b/src/components/SideNavMenu.tsx
@@ -59,7 +59,7 @@ const SideNavMenu = ({ activityId }: SideNavMenuProps) => {
   ];
 
   return (
-    <aside className='mx-auto h-[432px] w-full max-w-[344px] min-w-[251px] flex-none rounded-lg border border-gray-300 bg-white px-4 py-6 shadow-md max-[900px]:max-w-[251px]'>
+    <aside className='mx-auto h-[444px] w-full max-w-[344px] min-w-[251px] flex-none rounded-lg border border-gray-300 bg-white px-4 py-6 shadow-md max-[900px]:max-w-[251px]'>
       <div className='flex justify-center'>
         <div className='relative w-fit'>
           <ProfileImage size='large' src={previewImage || profileImageUrl} />


### PR DESCRIPTION
## :hash: ### Issue

<!-- 이슈 번호를 작성해 주세요. - close #을 입력하면 이슈 번호가 나타납니다. -->
- close #137 

## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
체험 목록 페이지
- AllActivityItem.tsx 체험 아이템 텍스트 영역 클릭했을 체험 상세 페이지 이동하도록(텍스트 영역에 호버했을 때도 이미지 호버 scale 스타일 적용)
- BestActivitiesBanner.tsx 배너 클릭시 해당 체험 상세 페이지로 이동하도록 설정함
- Category.tsx 배경색 white 설정

다른 개선 사항
- 토스트 너비 320px로 고정(기존 태블릿과 데스크톱이었을 때 320px이었으나 모바일일 땐 너비가 더 커져 화면 전체를 차지했음)
- 토스트 표시 1.5초로 설정
- 체험 등록, 수정 시 토스트가 다 표시되기도 전에 my-activities로 리다이렉트되어 토스트 표시를 볼 수 없었던 걸 setTimeout과 useRouter를 사용해 해결함
- 체험 등록, 수정 시 날짜 선택하는 DatePicker의 위치가 모바일일 때 왼쪽이 잘리던 버그가 있어서 수정함
- 날짜 선택기 옆 캘린더 이미지 추가(모바일일 땐 자리가 부족해 hidden 처리함)
- metadata 작성(추후 metadataBase URL 최종 배포 URL로 변경해야 함)

![스크린샷 2025-04-09 111448](https://github.com/user-attachments/assets/7e618422-ebbb-46c2-883e-1a9f0905f567)
![스크린샷 2025-04-09 130011](https://github.com/user-attachments/assets/1188e511-4426-4a6b-b6e7-cae8a6f5f592)
![스크린샷 2025-04-09 130026](https://github.com/user-attachments/assets/b6f10d45-e5cd-4323-8c79-0efeee3c1901)

## :white_check_mark: Checklist

### PR Checklist


<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
